### PR TITLE
Resolve issue of failed open of log.

### DIFF
--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -58,6 +58,15 @@ prune(Node, Key, Until) ->
     riak_core_vnode_master:sync_command(Node, {prune, Key, Until}, ?LOGGINGMASTER).
 
 init([Partition]) ->
+    LogFile = string:concat(integer_to_list(Partition), "log"),
+    LogPath = filename:join(
+            app_helper:get_env(riak_core, platform_data_dir), LogFile),
+    case dets:open_file(LogFile, [{file, LogPath}, {type, bag}]) of
+        {ok, Log} ->
+            {ok, #state{partition=Partition, log=Log}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 handle_command({read, Key}, _Sender, #state{partition=Partition, log=Log}=State) ->
     case dets:lookup(Log, Key) of


### PR DESCRIPTION
If the log can't be opened, fail the starting of the vnode instead of relying on a bad match triggering the vnode to repeatedly trigger max_restart_intensity.
