### PR TITLE
Remove unused functions; change to lager.

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -10,6 +10,14 @@
               {handoff_port, {{handoff_port}} }
              ]},
 
+ {lager, [
+   {handlers, [
+     {lager_console_backend, info},
+     {lager_file_backend, [{file, "error.log"}, {level, error}]},
+     {lager_file_backend, [{file, "console.log"}, {level, info}]} 
+   ]}
+ ]},
+
  %% SASL config
  {sasl, [
          {sasl_error_logger, {file, "log/sasl-error.log"}},

--- a/src/floppy.erl
+++ b/src/floppy.erl
@@ -2,57 +2,27 @@
 -include("floppy.hrl").
 -include_lib("riak_core/include/riak_core_vnode.hrl").
 
--export([
-	 append/2,
-	 read/2,
-	 %startTX/2,
-	 types/0
-        ]).
-
--ignore_xref([
-              ping/0
-             ]).
+-export([append/2,
+         read/2]).
 
 %% Public API
 
-types()->
-   io:fwrite("riak_dt_disable_flag~n",[]),
-   io:format("riak_dt_enable_flag~n"),
-   io:format("riak_dt_gcounter~n"),
-   io:format("riak_dt_gset~n"),
-   io:format("riak_dt_lwwreg~n"),
-   io:format("riak_dt_map~n"),
-   io:format("riak_dt_od_flag~n"),
-   io:format("riak_dt_oe_flag~n"),
-   io:format("riak_dt_orset~n"),
-   io:format("riak_dt_orswot~n"),
-   io:format("riak_dt_pncounter~n").
-
-%dcreate(Key, Type) ->
-%   floppy_coord_sup:start_fsm([100, self(), create, Key, Type]).
-
 append(Key, Op) ->
+    lager:info("Append called!"),
     case floppy_rep_vnode:append(Key, Op) of
-	{ok, Result} ->
-	    %inter_dc_repl_vnode:propogate(Key, Op),
-	    {ok, Result};
-	{error, Reason} ->
-	    {error, Reason}
+        {ok, Result} ->
+            {ok, Result};
+        {error, Reason} ->
+            {error, Reason}
     end.
-	
 
 read(Key, Type) ->
     case floppy_rep_vnode:read(Key, Type) of
-	{ok, Ops} ->
-    	    Init=materializer:create_snapshot(Type),
-	    Snapshot=materializer:update_snapshot(Type, Init, Ops),
-	    Value=Type:value(Snapshot),
-	    Value;
+        {ok, Ops} ->
+            Init=materializer:create_snapshot(Type),
+            Snapshot=materializer:update_snapshot(Type, Init, Ops),
+            Type:value(Snapshot);
         {error, _} ->
-	    io:format("Read failed!~n"),
-	    error
+            lager:info("Read failed!~n"),
+            error
     end.
-
-%% Clock SI API
-%startTX(ClientClock, Operations) ->
-%		clockSI_tx_coord_sup:start_fsm([self(), ClientClock, Operations]).	

--- a/src/floppy_coord_fsm.erl
+++ b/src/floppy_coord_fsm.erl
@@ -32,7 +32,7 @@ start_link(From, Op, Key, Param) ->
     gen_fsm:start_link(?MODULE, [From, Op, Key, Param], []).
 
 %start_link(Key, Op) ->
-%    io:format('The worker is about to start~n'),
+%    lager:info('The worker is about to start~n'),
 %    gen_fsm:start_link(?MODULE, [Key, , Op, ], []).
 
 finishOp(From, Key,Result) ->
@@ -68,15 +68,15 @@ execute(timeout, SD0=#state{
                             key=Key,
                             param=Param,
                             preflist=Preflist}) ->
-    io:format("Coord: Execute operation ~w ~w ~w~n",[Op, Key, Param]),
+    lager:info("Coord: Execute operation ~w ~w ~w~n",[Op, Key, Param]),
     case Preflist of 
 	[] ->
-	    io:format("Coord: Nothing in pref list~n"),
+	    lager:info("Coord: Nothing in pref list~n"),
 	    {stop, normal, SD0};
 	[H|T] ->
 	    %% Send the operation to the first vnode in the preflist;
 	    %% Will timeout if the vnode does not respond within INDC_TIMEOUT
-	    io:format("Coord: Forward to node~w~n",[H]),
+	    lager:info("Coord: Forward to node~w~n",[H]),
 	    {IndexNode, _} = H,
 	    floppy_rep_vnode:handleOp(IndexNode, self(), Op, Key, Param), 
             SD1 = SD0#state{preflist=T},
@@ -89,13 +89,13 @@ waiting(timeout, SD0=#state{op=Op,
 			   key=Key,
 			   param=Param,
 			   preflist=Preflist}) ->
-    io:format("Coord: INDC_TIMEOUT, retry...~n"),
+    lager:info("Coord: INDC_TIMEOUT, retry...~n"),
     case Preflist of 
 	[] ->
-	    io:format("Coord: Nothing in pref list~n"),
+	    lager:info("Coord: Nothing in pref list~n"),
 	    {stop, normal, SD0};
 	[H|T] ->
-	    io:format("Coord: Forward to node:~w~n",[H]),
+	    lager:info("Coord: Forward to node:~w~n",[H]),
 	    {IndexNode, _} = H,
 	    floppy_rep_vnode:handleOp(IndexNode, self(), Op, Key, Param), 
             SD1 = SD0#state{preflist=T},
@@ -104,7 +104,7 @@ waiting(timeout, SD0=#state{op=Op,
 
 %% @doc Receive result and reply the result to the process that started the fsm (From). 
 waiting({Key, Val}, SD=#state{from=From}) ->
-    io:format("Coord: Finish operation ~w ~w ~n",[Key,Val]),
+    lager:info("Coord: Finish operation ~w ~w ~n",[Key,Val]),
     %proxy:returnResult(Key, Val, Client),
     From! {Key,Val},   
     {stop, normal, SD};

--- a/src/floppy_rep_vnode.erl
+++ b/src/floppy_rep_vnode.erl
@@ -47,14 +47,14 @@ init([Partition]) ->
 %% Args: Key of the object and operation parameters
 %% Returns: {ok, Result} if success; {error, timeout} if operation failed.
 append(Key, Op) ->
-    io:format("Append ~w ~w ~n", [Key, Op]),
+    lager:info("Append ~w ~w ~n", [Key, Op]),
     floppy_coord_sup:start_fsm([self(), append, Key, Op]),
     receive
         {_, Result} ->
-	    io:format("Append completed!~w~n",[Result]),
+	    lager:info("Append completed!~w~n",[Result]),
 	    {ok, Result}
     after 5000 ->
-	    io:format("Append failed!~n"),
+	    lager:info("Append failed!~n"),
 	    {error, timeout}
     end.
 
@@ -63,14 +63,14 @@ append(Key, Op) ->
 %% Args: Key of the object and its type, which should be supported by the riak_dt.
 %% Returns: {ok, Ops} if succeeded, Ops is the union of operations; {error, nothing} if operation failed.
 read(Key, Type) ->
-    io:format("Read ~w ~w ~n", [Key, Type]),
+    lager:info("Read ~w ~w ~n", [Key, Type]),
     floppy_coord_sup:start_fsm([self(), read, Key, noop]),
     receive
         {_, Ops} ->
-	    io:format("Read completed!~n"),
+	    lager:info("Read completed!~n"),
 	    {ok,Ops}
     after 5000 ->
-	    io:format("Read failed!~n"),
+	    lager:info("Read failed!~n"),
 	    {error, nothing}
     end.
 
@@ -92,11 +92,11 @@ handle_command({operate, ToReply, Op, Key, Param}, _Sender, #state{partition=Par
 	read  ->
 	OpId = current_op_id(LC);
 	_ ->
-	io:format("RepVNode: Wrong operations!~w~n", [Op]),
+	lager:info("RepVNode: Wrong operations!~w~n", [Op]),
 	OpId = current_op_id(LC)
       end,
       {NewClock,_} = OpId,
-      io:format("RepVNode: Start replication, clock: ~w~n",[NewClock]),
+      lager:info("RepVNode: Start replication, clock: ~w~n",[NewClock]),
       floppy_rep_sup:start_fsm([ToReply, Op, Key, Param, OpId]),
       {noreply, #state{lclock=NewClock, partition= Partition}};
 

--- a/src/inter_dc_recvr.erl
+++ b/src/inter_dc_recvr.erl
@@ -17,7 +17,7 @@ start_link() ->
     {ok, PID}.
 
 replicate(Node, Payload, Origin) ->
-    io:format("Sending update ~p to ~p ~n",[Payload, Node]),
+    lager:info("Sending update ~p to ~p ~n",[Payload, Node]),
     gen_server:cast(Node, {replicate, Payload, from, Origin}).
 
 stop(Pid)->
@@ -39,11 +39,11 @@ handle_call(terminate, _From, State) ->
     {stop, normal, ok, State}.
    
 handle_info(Msg, State) ->
-    io:format("Unexpected message: ~p~n",[Msg]),
+    lager:info("Unexpected message: ~p~n",[Msg]),
     {noreply, State}.
 
 terminate(normal, _State) ->
-    io:format("Inter_dc_repl_recvr stopping"),
+    lager:info("Inter_dc_repl_recvr stopping"),
     ok;
 terminate(_Reason, _State) -> ok.
 
@@ -56,15 +56,15 @@ code_change(_OldVsn, State, _Extra) ->
 %private
 
 apply(Payload) ->
-    io:format("Recieved update ~p ~n",[Payload]),
+    lager:info("Recieved update ~p ~n",[Payload]),
     {Key, Op} = Payload,
     %%TODO: Replace this with proper replication protocol
     _ = floppy_coord_sup:start_fsm([self(), update, Key, Op]),
     receive 
 	{_, Result} ->
-	io:format("Updated ~p",[Result])
+	lager:info("Updated ~p",[Result])
 	after 5000 ->
-	io:format("Update failed!~n")
+	lager:info("Update failed!~n")
     end,
-    io:format("Updated operation ~p ~n", [Payload]),
+    lager:info("Updated operation ~p ~n", [Payload]),
     ok.

--- a/src/inter_dc_repl.erl
+++ b/src/inter_dc_repl.erl
@@ -52,7 +52,7 @@ ready(timeout, StateData = #state{otherdc = Other, otherpid = PID, retries = Ret
 	     ?TIMEOUT}.
 
 await_ack({ok,Payload}, StateData) ->
-    io:format("Replicated ~p ~n",[Payload]),
+    lager:info("Replicated ~p ~n",[Payload]),
     {stop, normal, StateData};
 await_ack(timeout,StateData = #state{retries = RetryLeft}) ->
     case RetryLeft of 


### PR DESCRIPTION
Remove a series of unused functions, and change io:format calls to use
lager.  Default to the lager_console_backend.
