### PR TITLE
Avoid quorum unavailable write.

### DIFF
--- a/riak_test/repfsm_error_handle_test.erl
+++ b/riak_test/repfsm_error_handle_test.erl
@@ -7,8 +7,7 @@
 -define(HARNESS, (rt_config:get(rt_harness))).
 
 confirm() ->
-    N=6,
-    [Nodes] = rt:build_clusters([N]),
+    [Nodes] = rt:build_clusters([6]),
 
     lager:info("Waiting for ring to converge."),
     rt:wait_until_ring_converged(Nodes),
@@ -20,12 +19,9 @@ handle_error_test(Nodes) ->
 
     %% Test when network partition happens, if error handling is happening.
     PartInfo = rt:partition([N1, N2, N4, N5, N6], [N3]),
-    
+
     WriteResult1 = rpc:call(N2, floppy, append, [key1, {increment, ucl}]),
     ?assertMatch({ok, _}, WriteResult1),
-
-    WriteResult3 = rpc:call(N3, floppy, append, [key1, {increment, ucl}]),
-    ?assertMatch({error, quorum_unreachable}, WriteResult3),
 
     ReadResult2 = rpc:call(N3, floppy, read, [key1, riak_dt_gcounter]),
     ?assertMatch({error, quorum_unreachable}, ReadResult2),
@@ -36,10 +32,11 @@ handle_error_test(Nodes) ->
     %% Test that values are actually written after network partition
     ReadResult3 = rpc:call(N3, floppy, read, [key1, riak_dt_gcounter]),
     lager:info("Value read: ~w",[ReadResult3]),
+    ?assertEqual(1, ReadResult3),
 
     ReadResult4 = rpc:call(N3, floppy, read, [key1, riak_dt_gcounter]),
-    ?assertEqual(ReadResult3, ReadResult4),
     lager:info("Value read: ~w",[ReadResult3]),
+    ?assertEqual(1, ReadResult4),
 
     _PartInfo2 = rt:partition([N1, N2, N3, N4, N5], [N6]),
 
@@ -48,4 +45,3 @@ handle_error_test(Nodes) ->
     ?assertMatch({error, can_not_reach_vnode}, ReadResult5),
 
     pass.
-    


### PR DESCRIPTION
Avoid the quorum unavailable write, which might succeed on one of the
nodes, triggering a transient failure in this test where the write
appears late and causes two subsequent reads to read two different
values.

This is an example of the partial write problem.

@aletomsic @marsleezm @angbrav @bieniusa 
