### PR TITLE
Make append operation supports type.

### DIFF
--- a/include/floppy.hrl
+++ b/include/floppy.hrl
@@ -1,7 +1,6 @@
 -define(BUCKET, <<"floppy">>).
 -define(MASTER, floppy_vnode_master).
 -define(LOGGINGMASTER, logging_vnode_master).
-%-define(CLOCKSIMASTER, clocksi_vnode_master).
 -define(REPMASTER, floppy_rep_vnode_master).
 -define(OP_TIMEOUT, 25000).
 -define(COORD_TIMEOUT, 5000).
@@ -10,7 +9,7 @@
 -define(NUM_W, 2).
 -define(NUM_R, 2).
 -define(OTHER_DC, 'floppy1@127.0.0.1').
--record (payload, {key, op_param, actor}).
+-record (payload, {key, type, op_param, actor}).
 -record(operation, {op_number, payload}).
 -type operation() :: #operation{}.
 

--- a/riak_test/append_failures_test.erl
+++ b/riak_test/append_failures_test.erl
@@ -24,7 +24,7 @@ confirm() ->
     First = hd(A),
 
     %% Perform successful write and read.
-    WriteResult = rpc:call(First, floppy, append, [key1, {increment, ucl}]),
+    WriteResult = rpc:call(First, floppy, append, [key1, riak_dt_gcounter, {increment, ucl}]),
     lager:info("WriteResult: ~p", [WriteResult]),
     ?assertMatch({ok, {1, _}}, WriteResult),
 
@@ -37,7 +37,7 @@ confirm() ->
     PartInfo = rt:partition(A, Nodes -- A),
 
     %% Write to the minority partition.
-    WriteResult2 = rpc:call(First, floppy, append, [key1, {increment, ucl}]),
+    WriteResult2 = rpc:call(First, floppy, append, [key1, riak_dt_gcounter, {increment, ucl}]),
     lager:info("WriteResult2: ~p", [WriteResult2]),
     ?assertMatch({error, quorum_unreachable}, WriteResult2),
 

--- a/riak_test/append_test.erl
+++ b/riak_test/append_test.erl
@@ -18,14 +18,14 @@ confirm() ->
 
     WriteResult = rpc:call(Node,
                            floppy, append,
-                           [key1, {increment, ucl}]),
+                           [key1, riak_dt_gcounter, {increment, ucl}]),
     ?assertMatch({ok, _}, WriteResult),
 
     rt:log_to_nodes(Nodes, "Starting write operation 2"),
 
     WriteResult2 = rpc:call(Node,
                            floppy, append,
-                           [key2, {increment, ucl}]),
+                           [key2, riak_dt_gcounter, {increment, ucl}]),
     ?assertMatch({ok, _}, WriteResult2),
 
     rt:log_to_nodes(Nodes, "Starting read operation 1"),

--- a/riak_test/floppy_log_handoff_test.erl
+++ b/riak_test/floppy_log_handoff_test.erl
@@ -65,7 +65,7 @@ test_handoff(RootNode, NewNode, NTestItems) ->
 
 multiple_writes(Node, Start, End, Actor)->
     F = fun(N, Acc) ->
-            case rpc:call(Node, floppy, append, [N, {{increment, N}, Actor}]) of
+            case rpc:call(Node, floppy, append, [N, riak_dt_gcounter, {{increment, N}, Actor}]) of
                 {ok, _} ->
                     Acc;
                 Other ->

--- a/riak_test/floppy_log_test.erl
+++ b/riak_test/floppy_log_test.erl
@@ -29,7 +29,7 @@ confirm() ->
             Node = lists:nth(Elem, Nodes),
             lager:info("Sending append to Node ~w~n",[Node]),
             WriteResult = rpc:call(Node,
-                                   floppy, append, [abc, {increment, 4}]),
+                                   floppy, append, [abc, riak_dt_gcounter, {increment, 4}]),
             ?assertMatch({ok, _}, WriteResult),
             Acc + 1
     end,

--- a/riak_test/mvreg_test.erl
+++ b/riak_test/mvreg_test.erl
@@ -17,7 +17,7 @@ confirm() ->
     F = fun(Elem) ->
             Node = lists:nth(Elem, Nodes),
             lager:info("Sending asign to Node ~w~n",[Node]),
-            AssignResult = rpc:call(Node, floppy, append, [abc, {{assign, Elem}, actor1}]),
+            AssignResult = rpc:call(Node, floppy, append, [abc, riak_dt_mvreg, {{assign, Elem}, actor1}]),
             ?assertMatch({ok, _}, AssignResult)
     end,
 
@@ -28,13 +28,13 @@ confirm() ->
     {ok, ReadResult} = rpc:call(FirstNode, floppy, read, [abc, riak_dt_mvreg]),
     ?assertEqual([Result], ReadResult),
 
-    PropagateResult1 = rpc:call(FirstNode, floppy, append, [abc, {{propagate, value2, [{actor2, 5}]}, actor1}]),
+    PropagateResult1 = rpc:call(FirstNode, floppy, append, [abc, riak_dt_mvreg, {{propagate, value2, [{actor2, 5}]}, actor1}]),
     ?assertMatch({ok, _}, PropagateResult1),
     {ok, ReadResult1} = rpc:call(FirstNode, floppy, read, [abc, riak_dt_mvreg]),
     Result1 = [Result, value2],
     ?assertEqual(lists:sort(Result1), lists:sort(ReadResult1)),
 
-    PropagateResult2 = rpc:call(FirstNode, floppy, append, [abc, {{propagate, value3, [{actor2, 6}, {actor1, 11}]}, actor1}]),
+    PropagateResult2 = rpc:call(FirstNode, floppy, append, [abc, riak_dt_mvreg, {{propagate, value3, [{actor2, 6}, {actor1, 11}]}, actor1}]),
     ?assertMatch({ok, _}, PropagateResult2),
     {ok, ReadResult2} = rpc:call(FirstNode, floppy, read, [abc, riak_dt_mvreg]),
     ?assertEqual([value3], ReadResult2),

--- a/riak_test/replication_test.erl
+++ b/riak_test/replication_test.erl
@@ -1,3 +1,20 @@
+%% @doc replication_test: Test that check whether replication works
+%% properly. Let's say, the replicas of the key is N3, N4, N5.
+%%
+%% First call `append/3' and then check if at least two replicas have 
+%% applied that operation.
+%%
+%% Secondly, create a network partition ([N3, N4], [N5]) and checks
+%% if `append/3'is successful, [N3, N4] both applied the operation.
+%%
+%% Finally, heal the network partition and create a new partition
+%% ([N3], [N4, N5]) and checks if `read/2' from [N4, N5] returns the correct
+%% value. Checking if N5 is repaired with the full set of operations is covered
+%% by append_list_test.
+
+%%  Input:  Nodes:  List of the nodes of the cluster
+%%
+
 -module(replication_test).
 
 -export([confirm/0, send_multiple_updates/4]).
@@ -15,21 +32,6 @@ confirm() ->
 
     replication_test(Nodes).
 
-%% @doc replication_test: Test that check whether replication works
-%% properly. Let's say, the replicas of the key is N3, N4, N5.
-%%
-%% First call `append/2' and then check if at least two replicas have 
-%% applied that operation.
-%%
-%% Secondly, create a network partition ([N3, N4], [N5]) and checks
-%% if `append/2'is successful, [N3, N4] both applied the operation.
-%%
-%% Finally, heal the network partition and create a new partition
-%% ([N3], [N4, N5]) and checks if `read/2' from [N4, N5] returns the correct
-%% value. Checking if N5 is repaired with the full set of operations is covered
-%% by append_list_test.
-
-%%  Input:  Nodes:  List of the nodes of the cluster
 replication_test(Nodes) ->
     [N1|_] = Nodes,
     Key = key1,
@@ -38,70 +40,35 @@ replication_test(Nodes) ->
     Preflist = rpc:call(N1, log_utilities, get_apl_from_logid, [LogId, logging]),
     lager:info("LogId ~w: Preflist ~w",[LogId, Preflist]),
     NodesRep = [Node || {_Index, Node} <- Preflist],
-    
+
     lager:info("Nodes that replicate ~w: ~w",[Key, NodesRep]),
 
-    WriteResult = rpc:call(hd(NodesRep), floppy, append, [Key, {increment, ucl}]),
+    WriteResult = rpc:call(hd(NodesRep), floppy, append, [Key, riak_dt_gcounter, {increment, ucl}]),
     ?assertMatch({ok, _}, WriteResult),
-    {ok, OpId} = WriteResult, 
+    {ok, OpId} = WriteResult,
 
-    Payload = {payload, key1, increment, ucl},
+    Payload = {payload, key1, riak_dt_gcounter, increment, ucl},
     NumOfRecord1 = read_matches(LogId, Preflist, [{LogId, {operation, OpId, Payload}}]),
     ?assertMatch(true, NumOfRecord1 >=2),
-    
-    %% Second test
-%    Excluded1 = hd(lists:reverse(NodesRep)),
-%    Part1 = lists:filter(fun(Elem) -> Elem /= Excluded1 end, Nodes),   %%tl(lists:reverse(NodesRep)),
-
- %   PartInfo1 = rt:partition(Part1, [Excluded1]),
-
-  %  NewOpIds = send_multiple_updates(hd(Part1), 4, [], Key),
-  %  lager:info("Total: ~w",[NewOpIds]),
-
- %   OpIds = [OpId]++NewOpIds,
- %   Records = [{LogId, {operation, Id, Payload}}|| Id <- OpIds],
- %   NumOfRecord2 = read_matches(LogId, Preflist, Records),
- %   ?assertEqual(2, NumOfRecord2),
-
-%    Result2 = rpc:call(Excluded1, floppy, append, [Key, {increment, ucl}]),
-%    ?assertMatch({error, _}, Result2),
-
-    %% Third test
- %   ok = rt:heal(PartInfo1),
- %   ok = rt:wait_for_cluster_service(Nodes, replication),
-
- %   Excluded2 = hd(NodesRep),
- %   Part2 = lists:filter(fun(Elem) -> Elem /= Excluded2 end, Nodes),   %%tl(lists:reverse(NodesRep)),
- %   lager:info("Part ~w", [Part2]),
- %   _PartInfo2 = rt:partition(Part2, [Excluded2]),
-
- %   lager:info("Cluster splitted"),
- %   Result3 = rpc:call(hd(Part2), floppy, read, [Key, riak_dt_gcounter]),
- %   lager:info("Value read: ~w",[Result3]),
- %   ?assertEqual(Result3, 6),
     pass.
-
-
 
 read_matches(LogId, Preflist, Record) ->
     Results = [rpc:call(N, logging_vnode, read, [{I, N}, LogId])|| {I, N} <- Preflist],
     Ops = [Op ||{ok, {_,Op}} <- Results],
     SortedRecord = lists:sort(Record),
-    NewSum = lists:foldl(fun(X, Sum) -> case lists:sort(X) of 
+    NewSum = lists:foldl(fun(X, Sum) -> case lists:sort(X) of
                                     SortedRecord -> Sum+1;
                                     _ -> Sum
-                             end 
+                             end
                 end, 0, Ops),
     NewSum.
-        
-
 
 send_multiple_updates(Node, Total, OpIds, Key) ->
     case Total of
         0 ->
             OpIds;
         _ ->
-            WriteResult = rpc:call(Node, floppy, append, [Key, {increment, ucl}]),
+            WriteResult = rpc:call(Node, floppy, append, [Key, riak_dt_gcounter, {increment, ucl}]),
             ?assertMatch({ok, _}, WriteResult),
             {ok, OpId} = WriteResult,
             send_multiple_updates(Node, Total - 1, OpIds++[OpId], Key)

--- a/src/floppy.erl
+++ b/src/floppy.erl
@@ -2,15 +2,15 @@
 
 -include("floppy.hrl").
 
--export([append/2, read/2]).
+-export([append/3, read/2]).
 
 %% Public API
 
 %% @doc The append/2 function adds an operation to the log of the CRDT
 %%      object stored at some key.
-append(Key, {OpParam, Actor}) ->
-    Payload = #payload{key=Key, op_param=OpParam, actor=Actor},
-    case floppy_rep_vnode:append(Key, Payload) of
+append(Key, Type, {OpParam, Actor}) ->
+    Payload = #payload{key=Key, type=Type, op_param=OpParam, actor=Actor},
+    case floppy_rep_vnode:append(Key, Type, Payload) of
         {ok, Result} ->
             {ok, Result};
         {error, Reason} ->
@@ -20,7 +20,7 @@ append(Key, {OpParam, Actor}) ->
 %% @doc The read/2 function returns the current value for the CRDT
 %%      object stored at some key.
 read(Key, Type) ->
-    case floppy_rep_vnode:read(Key) of
+    case floppy_rep_vnode:read(Key, Type) of
         {ok, Ops} ->
             Init = materializer:create_snapshot(Type),
             Snapshot = materializer:update_snapshot(Key, Type, Init, Ops),

--- a/src/floppy_pb_counter.erl
+++ b/src/floppy_pb_counter.erl
@@ -41,12 +41,12 @@ encode(Message) ->
 
 %% @doc process/2 callback. Handles an incoming request message.
 process(#fpbincrementreq{key=Key, amount=Amount}, State) ->
-    {ok, _Result} = floppy:append(Key, {{increment, Amount}, node()}),
+    {ok, _Result} = floppy:append(Key, riak_dt_pncounter, {{increment, Amount}, node()}),
     {reply, #fpboperationresp{success = true}, State};
 
 %% @doc process/2 callback. Handles an incoming request message.
 process(#fpbdecrementreq{key=Key, amount=Amount}, State) ->
-    {ok, _Result} = floppy:append(Key, {{decrement, Amount}, node()}),
+    {ok, _Result} = floppy:append(Key, riak_dt_pncounter, {{decrement, Amount}, node()}),
     {reply, #fpboperationresp{success = true}, State};
 
 %% @doc process/2 callback. Handles an incoming request message.

--- a/src/floppy_pb_set.erl
+++ b/src/floppy_pb_set.erl
@@ -41,11 +41,11 @@ encode(Message) ->
 process(#fpbsetupdatereq{key=Key, adds=AddsBin, rems=RemsBin}, State) ->
     lists:foreach(fun(X) ->
                           Elem = erlang:binary_to_term(X),
-                          floppy:append(Key, {{add, Elem}, node()})
+                          floppy:append(Key, riak_dt_orset, {{add, Elem}, node()})
                   end,AddsBin),
     lists:foreach(fun(X) ->
                           Elem = erlang:binary_to_term(X),
-                          floppy:append(Key, {{remove, Elem}, node()})
+                          floppy:append(Key, riak_dt_orset, {{remove, Elem}, node()})
                   end,RemsBin),
     {reply, #fpboperationresp{success = true}, State};
 

--- a/src/materializer.erl
+++ b/src/materializer.erl
@@ -21,8 +21,8 @@ update_snapshot(Key, Type, Snapshot, [LogEntry|Rest]) ->
     case LogEntry of
         {_, Operation} ->
             Payload = Operation#operation.payload,
-            NewSnapshot = case Payload#payload.key of
-                Key ->
+            NewSnapshot = case {Payload#payload.key, Payload#payload.type} of
+                {Key, Type} ->
                     OpParam = Payload#payload.op_param,
                     Actor = Payload#payload.actor,
                     lager:info("OpParam: ~p, Actor: ~p and Snapshot: ~p",
@@ -45,10 +45,11 @@ update_snapshot(Key, Type, Snapshot, [LogEntry|Rest]) ->
 materializer_gcounter_withlog_test() ->
     GCounter = create_snapshot(riak_dt_gcounter),
     ?assertEqual(0,riak_dt_gcounter:value(GCounter)),
-    Ops = [{1,#operation{payload = #payload{key=key, op_param=increment, actor=actor1}}}, 
-    {2,#operation{payload =#payload{key=key, op_param=increment, actor=actor2}}}, 
-    {3,#operation{payload =#payload{key=key, op_param=increment, actor=actor3}}}, 
-    {4,#operation{payload =#payload{key=key, op_param={increment,3}, actor=actor4}}}],
+    Ops = [{1,#operation{payload = #payload{key=key,
+                                            type=riak_dt_gcounter, op_param=increment, actor=actor1}}}, 
+    {2,#operation{payload =#payload{key=key, type=riak_dt_gcounter, op_param=increment, actor=actor2}}}, 
+    {3,#operation{payload =#payload{key=key, type=riak_dt_gcounter, op_param=increment, actor=actor3}}}, 
+    {4,#operation{payload =#payload{key=key, type=riak_dt_gcounter, op_param={increment,3}, actor=actor4}}}],
     GCounter2 = update_snapshot(key, riak_dt_gcounter, GCounter, Ops),
     ?assertEqual(6,riak_dt_gcounter:value(GCounter2)).
 
@@ -68,7 +69,7 @@ materializer_error_nocreate_test() ->
 materializer_error_invalidupdate_test() ->
     GCounter = create_snapshot(riak_dt_gcounter),
     ?assertEqual(0,riak_dt_gcounter:value(GCounter)),
-    Ops = [{1,#operation{payload =#payload{key=key, op_param=decrement, actor=actor1}}}],
+    Ops = [{1,#operation{payload =#payload{key=key, type=riak_dt_gcounter, op_param=decrement, actor=actor1}}}],
     ?assertException(error, function_clause, update_snapshot(key, riak_dt_gcounter, GCounter, Ops)).
 
 -endif.


### PR DESCRIPTION
Make the append operation require a type; objects are keyed off of type
and key, so it is possible for a key to exist as both a G-Counter and a
PN-Counter.  Require the type for all operations.

Addresses #29 and #60. 

cc: @rsltrifork @bieniusa 
