### PR TITLE
Txs single partition

### DIFF
--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -33,7 +33,6 @@
          clocksi_istart_tx/0,
          clocksi_iread/3,
          clocksi_iupdate/4,
-         clocksi_iprepare/1,
          clocksi_icommit/1]).
 
 %% Public API
@@ -130,8 +129,6 @@ clocksi_iread({_, _, CoordFsmPid}, Key, Type) ->
 clocksi_iupdate({_, _, CoordFsmPid}, Key, Type, OpParams) ->
     gen_fsm:sync_send_event(CoordFsmPid, {update, {Key, Type, OpParams}}).
 
-clocksi_iprepare({_, _, CoordFsmPid})->
-    gen_fsm:sync_send_event(CoordFsmPid, {prepare, empty}).
-
 clocksi_icommit({_, _, CoordFsmPid})->
+    gen_fsm:sync_send_event(CoordFsmPid, {prepare, empty}),
     gen_fsm:sync_send_event(CoordFsmPid, commit).

--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -130,5 +130,4 @@ clocksi_iupdate({_, _, CoordFsmPid}, Key, Type, OpParams) ->
     gen_fsm:sync_send_event(CoordFsmPid, {update, {Key, Type, OpParams}}).
 
 clocksi_icommit({_, _, CoordFsmPid})->
-    gen_fsm:sync_send_event(CoordFsmPid, {prepare, empty}),
-    gen_fsm:sync_send_event(CoordFsmPid, commit).
+    gen_fsm:sync_send_event(CoordFsmPid, {prepare, empty}).

--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -33,6 +33,8 @@
          clocksi_istart_tx/0,
          clocksi_iread/3,
          clocksi_iupdate/4,
+         clocksi_iprepare/1,
+         clocksi_full_icommit/1,
          clocksi_icommit/1]).
 
 %% Public API
@@ -129,5 +131,15 @@ clocksi_iread({_, _, CoordFsmPid}, Key, Type) ->
 clocksi_iupdate({_, _, CoordFsmPid}, Key, Type, OpParams) ->
     gen_fsm:sync_send_event(CoordFsmPid, {update, {Key, Type, OpParams}}).
 
-clocksi_icommit({_, _, CoordFsmPid})->
+%% @doc This commits includes both prepare and commit phase. Thus
+%%      Client do not need to send to message to complete the 2PC
+%%      protocol. The Tx coordinator will pick the best strategie
+%%      automatically.
+clocksi_full_icommit({_, _, CoordFsmPid})->
     gen_fsm:sync_send_event(CoordFsmPid, {prepare, empty}).
+    
+clocksi_iprepare({_, _, CoordFsmPid})->
+    gen_fsm:sync_send_event(CoordFsmPid, {prepare, two_phase}).
+
+clocksi_icommit({_, _, CoordFsmPid})->
+    gen_fsm:sync_send_event(CoordFsmPid, commit).

--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -189,11 +189,6 @@ prepare_2pc(timeout, SD0=#state{
             gen_fsm:reply(From, {ok, Snapshot_time}),
             {next_state, committing_2pc,
             SD0#state{state=committing, commit_time=Snapshot_time}};
-        1-> 
-            clocksi_vnode:prepare(Updated_partitions, Transaction),
-            Num_to_ack=length(Updated_partitions),
-            {next_state, receive_prepared,
-            SD0#state{num_to_ack=Num_to_ack, state=prepared}};
         _->
             clocksi_vnode:prepare(Updated_partitions, Transaction),
             Num_to_ack=length(Updated_partitions),

--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -37,8 +37,8 @@
          handle_sync_event/4, terminate/3]).
 
 %% States
--export([execute_op/3, finish_op/3, prepare/2,
-         receive_prepared/2, single_committing/2, committing/3, receive_committed/2, abort/2,
+-export([execute_op/3, finish_op/3, prepare/2, prepare_2pc/2,
+         receive_prepared/2, single_committing/2, committing_2pc/3, committing/2, receive_committed/2, abort/2,
          reply_to_client/2]).
 
 %%---------------------------------------------------------------------
@@ -60,6 +60,7 @@
           num_to_ack :: integer(),
           prepare_time :: integer(),
           commit_time :: integer(),
+          commit_protocol :: term(),
           state:: atom()}).
 
 %%%===================================================================
@@ -109,7 +110,12 @@ execute_op({Op_type, Args}, Sender,
                       updated_partitions=Updated_partitions}) ->
     case Op_type of
         prepare ->
-            {next_state, prepare, SD0#state{from=Sender}, 0};
+            case Args of
+            two_phase ->
+                {next_state, prepare_2pc, SD0#state{from=Sender, commit_protocol=Args}, 0};
+            _ ->
+                {next_state, prepare, SD0#state{from=Sender, commit_protocol=Args}, 0}
+            end;
         read ->
             {Key, Type}=Args,
             Preflist = log_utilities:get_preflist_from_key(Key),
@@ -152,40 +158,67 @@ execute_op({Op_type, Args}, Sender,
     end.
 
 
-%% @doc a message from a client wanting to start committing the tx.
-%%      this state sends a prepare message to all updated partitions and goes
+%% @doc this state sends a prepare message to all updated partitions and goes
 %%      to the "receive_prepared"state.
 prepare(timeout, SD0=#state{
+                        transaction = Transaction,
+                        updated_partitions=Updated_partitions, from=_From}) ->
+    case length(Updated_partitions) of
+        0->
+            Snapshot_time=Transaction#transaction.snapshot_time,
+            {next_state, committing,
+            SD0#state{state=committing, commit_time=Snapshot_time}, 0};
+        1-> 
+            clocksi_vnode:single_commit(Updated_partitions, Transaction),
+            {next_state, single_committing,
+            SD0#state{state=committing, num_to_ack=1}};
+        _->
+            clocksi_vnode:prepare(Updated_partitions, Transaction),
+            Num_to_ack=length(Updated_partitions),
+            {next_state, receive_prepared,
+            SD0#state{num_to_ack=Num_to_ack, state=prepared}}
+    end.
+%% @doc state called when 2pc is forced independently of the number of partitions
+%%      involved in the txs.
+prepare_2pc(timeout, SD0=#state{
                         transaction = Transaction,
                         updated_partitions=Updated_partitions, from=From}) ->
     case length(Updated_partitions) of
         0->
             Snapshot_time=Transaction#transaction.snapshot_time,
             gen_fsm:reply(From, {ok, Snapshot_time}),
-            {next_state, committing,
-             SD0#state{state=committing, commit_time=Snapshot_time}};
+            {next_state, committing_2pc,
+            SD0#state{state=committing, commit_time=Snapshot_time}};
         1-> 
-            clocksi_vnode:single_commit(Updated_partitions, Transaction),
-            {next_state, single_committing,
-             SD0#state{state=committing, num_to_ack=1}};
+            clocksi_vnode:prepare(Updated_partitions, Transaction),
+            Num_to_ack=length(Updated_partitions),
+            {next_state, receive_prepared,
+            SD0#state{num_to_ack=Num_to_ack, state=prepared}};
         _->
             clocksi_vnode:prepare(Updated_partitions, Transaction),
             Num_to_ack=length(Updated_partitions),
             {next_state, receive_prepared,
-             SD0#state{num_to_ack=Num_to_ack, state=prepared}}
+            SD0#state{num_to_ack=Num_to_ack, state=prepared}}
     end.
 
 %% @doc in this state, the fsm waits for prepare_time from each updated
 %%      partitions in order to compute the final tx timestamp (the maximum
 %%      of the received prepare_time).
 receive_prepared({prepared, ReceivedPrepareTime},
-                 S0=#state{num_to_ack= NumToAck,
-                           from= _From, prepare_time=PrepareTime}) ->
+                 S0=#state{num_to_ack=NumToAck,
+                           commit_protocol=CommitProtocol,
+                           from=From, prepare_time=PrepareTime}) ->
     MaxPrepareTime = max(PrepareTime, ReceivedPrepareTime),
     case NumToAck of 1 ->
-            {next_state, committing,
-             S0#state{prepare_time=MaxPrepareTime,
-                      commit_time=MaxPrepareTime, state=committing}, 0};
+            case CommitProtocol of
+            two_phase ->
+                gen_fsm:reply(From, {ok, MaxPrepareTime}),
+                {next_state, committing_2pc,
+                S0#state{prepare_time=MaxPrepareTime, commit_time=MaxPrepareTime, state=committing}};
+            _ ->
+                {next_state, committing,
+                S0#state{prepare_time=MaxPrepareTime, commit_time=MaxPrepareTime, state=committing}, 0}
+            end;
         _ ->
             {next_state, receive_prepared,
              S0#state{num_to_ack= NumToAck-1, prepare_time=MaxPrepareTime}}
@@ -202,10 +235,12 @@ single_committing({committed, CommitTime}, S0=#state{from=_From}) ->
     
 
 %% @doc after receiving all prepare_times, send the commit message to all
-%%       updated partitions, and go to the "receive_committed" state.
-committing(timeout, Sender, SD0=#state{transaction = Transaction,
-                                      updated_partitions=Updated_partitions,
-                                      commit_time=Commit_time}) ->
+%%      updated partitions, and go to the "receive_committed" state.
+%%      This state expects other process to sen the commit message to 
+%%      start the commit phase.
+committing_2pc(commit, Sender, SD0=#state{transaction = Transaction,
+                              updated_partitions=Updated_partitions,
+                              commit_time=Commit_time}) ->
     NumToAck=length(Updated_partitions),
     case NumToAck of
         0 ->
@@ -217,6 +252,25 @@ committing(timeout, Sender, SD0=#state{transaction = Transaction,
              SD0#state{num_to_ack=NumToAck, from=Sender, state=committing}}
     end.
 
+%% @doc after receiving all prepare_times, send the commit message to all
+%%      updated partitions, and go to the "receive_committed" state.
+%%      This state is used when no commit message from the client is
+%%      expected 
+committing(timeout, SD0=#state{transaction = Transaction,
+                              updated_partitions=Updated_partitions,
+                              commit_time=Commit_time}) ->
+    NumToAck=length(Updated_partitions),
+    case NumToAck of
+        0 ->
+            {next_state, reply_to_client,
+             SD0#state{state=committed},0};
+        _ ->
+            clocksi_vnode:commit(Updated_partitions, Transaction, Commit_time),
+            {next_state, receive_committed,
+             SD0#state{num_to_ack=NumToAck, state=committing}}
+    end.
+
+%% @doc the fsm waits for acks indicating that each partition has successfully
 
 %% @doc the fsm waits for acks indicating that each partition has successfully
 %%	committed the tx and finishes operation.

--- a/src/clocksi_static_tx_coord_fsm.erl
+++ b/src/clocksi_static_tx_coord_fsm.erl
@@ -107,17 +107,11 @@ execute_batch_ops(timeout, SD=#state{from = From,
                 end,
     ReadSet = lists:foldl(ExecuteOp, [], Operations),
     case gen_fsm:sync_send_event(TxCoordPid, {prepare, empty}, infinity) of
-        {ok, _} ->
-            case gen_fsm:sync_send_event(TxCoordPid, commit, infinity) of
-                {ok, {TxId, CommitTime}} ->
-                    From ! {ok, {TxId, ReadSet, CommitTime}},
-                    {stop, normal, SD};
-                _ ->
-                    From ! {error, commit_fail},
-                    {stop, normal, SD}
-            end;
-        {aborted, TxId} ->
-            From ! {error, {aborted, TxId}},
+        {ok, {TxId, CommitTime}} ->
+            From ! {ok, {TxId, ReadSet, CommitTime}},
+            {stop, normal, SD};
+        _ ->
+            From ! {error, commit_fail},
             {stop, normal, SD}
     end.
 

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -106,6 +106,8 @@ prepare(ListofNodes, TxId) ->
                                    {fsm, undefined, self()},
                                    ?CLOCKSI_MASTER).
 %% @doc Sends prepare+commit to a single partition
+%%      Called by a Tx coordinator when the tx only
+%%      affects one partition
 single_commit(Node, TxId) ->
     riak_core_vnode_master:command(Node,
                                    {single_commit, TxId},
@@ -312,6 +314,7 @@ terminate(_Reason, _State) ->
 %%%===================================================================
 %%% Internal Functions
 %%%===================================================================
+%% @doc Executes the prepare phase of this partition
 prepare(Transaction, WriteSet, CommittedTx, ActiveTxPerKey, PreparedTx, PrepareTime)->
     TxId = Transaction#transaction.txn_id,
     TxWriteSet = ets:lookup(WriteSet, TxId),
@@ -334,6 +337,7 @@ prepare(Transaction, WriteSet, CommittedTx, ActiveTxPerKey, PreparedTx, PrepareT
             {error, write_conflict}
     end.
 
+%% @doc Executes the commit phase of this partition
 commit(Transaction, TxCommitTime, WriteSet, CommittedTx, State)->
     TxId = Transaction#transaction.txn_id,
     DcId = dc_utilities:get_my_dc_id(),

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -18,7 +18,6 @@
 %%
 %% -------------------------------------------------------------------
 -module(clocksi_vnode).
-
 -behaviour(riak_core_vnode).
 
 -include("antidote.hrl").
@@ -29,6 +28,7 @@
          update_data_item/5,
          prepare/2,
          commit/3,
+         single_commit/2,
          abort/2,
          now_milisec/1,
          init/1,
@@ -105,6 +105,12 @@ prepare(ListofNodes, TxId) ->
                                    {prepare, TxId},
                                    {fsm, undefined, self()},
                                    ?CLOCKSI_MASTER).
+%% @doc Sends prepare+commit to a single partition
+single_commit(Node, TxId) ->
+    riak_core_vnode_master:command(Node,
+                                   {single_commit, TxId},
+                                   {fsm, undefined, self()},
+                                   ?CLOCKSI_MASTER).
 
 %% @doc Sends a commit request to a Node involved in a tx identified by TxId
 commit(ListofNodes, TxId, CommitTime) ->
@@ -174,37 +180,51 @@ handle_command({update_data_item, Txn, Key, Type, Op}, Sender,
             {reply, {error, Reason}, State}
     end;
 
+handle_command({single_commit, Transaction}, _Sender,
+               State = #state{partition=_Partition,
+                              committed_tx=CommittedTx,
+                              active_txs_per_key=ActiveTxPerKey,
+                              prepared_tx=PreparedTx,
+                              write_set=WriteSet}) ->
+    PrepareTime = now_milisec(erlang:now()),
+    Result = prepare(Transaction, WriteSet, CommittedTx, ActiveTxPerKey, PreparedTx, PrepareTime),
+    case Result of
+        {ok, _} ->
+            ResultCommit = commit(Transaction, PrepareTime, WriteSet, PreparedTx, State),
+            case ResultCommit of
+                {ok, committed} ->
+                    {reply, {committed, PrepareTime}, State};
+                {error, materializer_failure} ->
+                    {reply, {error, materializer_failure}, State};
+                {error, timeout} ->
+                    {reply, {error, timeout}, State};
+                {error, no_updates} ->
+                    {reply, no_tx_record, State}
+            end;
+        {error, timeout} ->
+            {reply, {error, timeout}, State};
+        {error, no_updates} ->
+            {reply, {error, no_tx_record}, State};
+        {error, write_conflict} ->
+            {reply, abort, State}
+    end;
+
 handle_command({prepare, Transaction}, _Sender,
                State = #state{partition=_Partition,
                               committed_tx=CommittedTx,
                               active_txs_per_key=ActiveTxPerKey,
                               prepared_tx=PreparedTx,
                               write_set=WriteSet}) ->
-    TxId = Transaction#transaction.txn_id,
-    TxWriteSet = ets:lookup(WriteSet, TxId),
-    case certification_check(TxId, TxWriteSet, CommittedTx, ActiveTxPerKey) of
-        true ->
-            PrepareTime = now_milisec(erlang:now()),
-            LogRecord = #log_record{tx_id=TxId,
-                                    op_type=prepare,
-                                    op_payload=PrepareTime},
-            true = ets:insert(PreparedTx, {active, {TxId, PrepareTime}}),
-            Updates = ets:lookup(WriteSet, TxId),
-            case Updates of 
-                [{_, {Key, _Type, {_Op, _Actor}}} | _Rest] -> 
-                    LogId = log_utilities:get_logid_from_key(Key),
-                    [Node] = log_utilities:get_preflist_from_key(Key),
-                    Result = logging_vnode:append(Node,LogId,LogRecord),
-                    case Result of
-                        {ok, _} ->
-                            {reply, {prepared, PrepareTime}, State};
-                        {error, timeout} ->
-                            {reply, {error, timeout}, State}
-                    end;
-                _ -> 
-                    {reply, {error, no_tx_record}, State}
-            end;
-        false ->
+    PrepareTime = now_milisec(erlang:now()),
+    Result = prepare(Transaction, WriteSet, CommittedTx, ActiveTxPerKey, PreparedTx, PrepareTime),
+    case Result of
+        {ok, _} ->
+            {reply, {prepared, PrepareTime}, State};
+        {error, timeout} ->
+            {reply, {error, timeout}, State};
+        {error, no_updates} ->
+            {reply, {error, no_tx_record}, State};
+        {error, write_conflict} ->
             {reply, abort, State}
     end;
 
@@ -215,32 +235,16 @@ handle_command({commit, Transaction, TxCommitTime}, _Sender,
                #state{partition=_Partition,
                       committed_tx=CommittedTx,
                       write_set=WriteSet} = State) ->
-    TxId = Transaction#transaction.txn_id,
-    DcId = dc_utilities:get_my_dc_id(),
-    LogRecord=#log_record{tx_id=TxId,
-                          op_type=commit,
-                          op_payload={{DcId, TxCommitTime},
-                                      Transaction#transaction.vec_snapshot_time}},
-    Updates = ets:lookup(WriteSet, TxId),
-    case Updates of
-        [{_, {Key, _Type, {_Op, _Param}}} | _Rest] -> 
-            LogId = log_utilities:get_logid_from_key(Key),
-            [Node] = log_utilities:get_preflist_from_key(Key),
-            case logging_vnode:append(Node,LogId,LogRecord) of
-                {ok, _} ->
-                    true = ets:insert(CommittedTx, {TxId, TxCommitTime}),
-                    case update_materializer(Updates, Transaction, TxCommitTime) of
-                        ok ->
-                            clean_and_notify(TxId, Key, State),
-                            {reply, committed, State};
-                        error ->
-                            {reply, {error, materializer_failure}, State}
-                    end;
-                {error, timeout} ->
-                    {reply, {error, timeout}, State}
-            end;
-        _ -> 
-            {reply, {error, no_tx_record}, State}
+    Result = commit(Transaction, TxCommitTime, WriteSet, CommittedTx, State),
+    case Result of
+        {ok, committed} ->
+            {reply, committed, State};
+        {error, materializer_failure} ->
+            {reply, {error, materializer_failure}, State};
+        {error, timeout} ->
+            {reply, {error, timeout}, State};
+        {error, no_updates} ->
+            {reply, no_tx_record, State}
     end;
 
 handle_command({abort, Transaction}, _Sender,
@@ -308,6 +312,56 @@ terminate(_Reason, _State) ->
 %%%===================================================================
 %%% Internal Functions
 %%%===================================================================
+prepare(Transaction, WriteSet, CommittedTx, ActiveTxPerKey, PreparedTx, PrepareTime)->
+    TxId = Transaction#transaction.txn_id,
+    TxWriteSet = ets:lookup(WriteSet, TxId),
+    case certification_check(TxId, TxWriteSet, CommittedTx, ActiveTxPerKey) of
+        true ->
+            LogRecord = #log_record{tx_id=TxId,
+                                    op_type=prepare,
+                                    op_payload=PrepareTime},
+            true = ets:insert(PreparedTx, {active, {TxId, PrepareTime}}),
+            Updates = ets:lookup(WriteSet, TxId),
+            case Updates of 
+                [{_, {Key, _Type, {_Op, _Actor}}} | _Rest] -> 
+                    LogId = log_utilities:get_logid_from_key(Key),
+                    [Node] = log_utilities:get_preflist_from_key(Key),
+                    logging_vnode:append(Node,LogId,LogRecord);
+                _ -> 
+                    {error, no_updates}
+            end;
+        false ->
+            {error, write_conflict}
+    end.
+
+commit(Transaction, TxCommitTime, WriteSet, CommittedTx, State)->
+    TxId = Transaction#transaction.txn_id,
+    DcId = dc_utilities:get_my_dc_id(),
+    LogRecord=#log_record{tx_id=TxId,
+                          op_type=commit,
+                          op_payload={{DcId, TxCommitTime},
+                                      Transaction#transaction.vec_snapshot_time}},
+    Updates = ets:lookup(WriteSet, TxId),
+    case Updates of
+        [{_, {Key, _Type, {_Op, _Param}}} | _Rest] -> 
+            LogId = log_utilities:get_logid_from_key(Key),
+            [Node] = log_utilities:get_preflist_from_key(Key),
+            case logging_vnode:append(Node,LogId,LogRecord) of
+                {ok, _} ->
+                    true = ets:insert(CommittedTx, {TxId, TxCommitTime}),
+                    case update_materializer(Updates, Transaction, TxCommitTime) of
+                        ok ->
+                            clean_and_notify(TxId, Key, State),
+                            {ok, committed};
+                        error ->
+                            {error, materializer_failure}
+                    end;
+                {error, timeout} ->
+                    {error, timeout}
+            end;
+        _ -> 
+            {error, no_updates}
+    end.
 
 %% @doc clean_and_notify:
 %%      This function is used for cleanning the state a transaction


### PR DESCRIPTION
Optimisation for transactions that affect only one partition. I have also added two tests to check that works. The operations clocksi_iprepare and clocks_icommit used for testing corner cases in the algorithm are still in the API. For benchmarking, the new operation clocks_full_icommit(we can change the name) should be used since it will take advantage of the optimisation and likely improve results. 