### PR TITLE
Fix build.

### DIFF
--- a/src/crdt_orset.erl
+++ b/src/crdt_orset.erl
@@ -42,25 +42,14 @@
 %% Convergent and Commutative Replicated Data Types. http://hal.upmc.fr/inria-00555588/
 %%
 %% @end
-
-
 -module(crdt_orset).
 
 %% API
 -export([new/0, value/1, generate_downstream/3, update/2, equal/2,
          to_binary/1, from_binary/1, value/2, precondition_context/1, stats/1, stat/2]).
 
--ifdef(EQC).
--include_lib("eqc/include/eqc.hrl").
--endif.
-
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--endif.
-
-%% EQC API
--ifdef(EQC).
--export([init_state/0, gen_op/0, update_expected/3, eqc_state_value/1]).
 -endif.
 
 -export_type([orset/0, binary_orset/0, orset_op/0]).

--- a/src/crdt_pncounter.erl
+++ b/src/crdt_pncounter.erl
@@ -50,12 +50,6 @@
 -export([new/0, new/1, value/1, value/2, update/2, generate_downstream/3, to_binary/1, from_binary/1]).
 -export([equal/2]).
 
-%% EQC API
--ifdef(EQC).
--include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, update_expected/3, eqc_state_value/1, init_state/0, generate/0]).
--endif.
-
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.


### PR DESCRIPTION
Resolve problems in the build where under a defined EQC compile, it
would attempt to export functions which were removed from the module.