### PR TITLE
Use supervisor pool.

### DIFF
--- a/src/antidote_pb_txn.erl
+++ b/src/antidote_pb_txn.erl
@@ -44,7 +44,7 @@ init() ->
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) ->
-    lager:info("Decoding Txn Req ~p",[Code]),
+    % lager:info("Decoding Txn Req ~p",[Code]),
     Msg = riak_pb_codec:decode(Code, Bin),
     case Msg of
         #fpbatomicupdatetxnreq{} ->
@@ -59,7 +59,7 @@ encode(Message) ->
 
 %% @doc process/2 callback. Handles an incoming request message.
 process(#fpbatomicupdatetxnreq{ops = Ops}, State) ->
-    lager:info("Testing txn interface.. Received atomic update request  ~p", [Ops]),
+    % lager:info("Testing txn interface.. Received atomic update request  ~p", [Ops]),
     Updates = decode_au_txn_ops(Ops),
     case antidote:clocksi_bulk_update(Updates) of
         {error, _Reason} ->
@@ -71,7 +71,7 @@ process(#fpbatomicupdatetxnreq{ops = Ops}, State) ->
     end;
 
 process(#fpbsnapshotreadtxnreq{ops = Ops}, State) ->
-    lager:info("Testing txn interface.. Received snapshot read request  ~p", [Ops]),
+    % lager:info("Testing txn interface.. Received snapshot read request  ~p", [Ops]),
     ReadReqs = decode_snapshot_read_ops(Ops),
     %%TODO: change this to interactive reads
     case antidote:clocksi_execute_tx(ReadReqs) of

--- a/src/clocksi_interactive_tx_coord_sup.erl
+++ b/src/clocksi_interactive_tx_coord_sup.erl
@@ -17,25 +17,37 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-%% @doc Supervise the fsm.
+
 -module(clocksi_interactive_tx_coord_sup).
+-author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
+
 -behavior(supervisor).
 
 -export([start_fsm/1,
          start_link/0]).
+
 -export([init/1]).
+
+-define(NUM, 100).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 start_fsm(Args) ->
-    supervisor:start_child(?MODULE, Args).
+    Random = random:uniform(?NUM),
+    Module = generate_module_name(Random),
+    supervisor:start_child(Module, Args).
+
+generate_module_name(N) ->
+    list_to_atom(atom_to_list(?MODULE) ++ "-" ++ integer_to_list(N)).
+
+generate_supervisor_spec(N) ->
+    Module = generate_module_name(N),
+    {Module,
+     {clocksi_interactive_tx_coord_worker_sup, start_link, [Module]},
+      permanent, 5000, worker, [clocksi_interactive_tx_coord_worker_sup]}.
 
 %% @doc Starts the coordinator of a ClockSI interactive transaction.
 init([]) ->
-    lager:info("clockSI_interactive_tx_coord_sup: Starting fsm..."),
-    Worker = {clocksi_interactive_tx_coord_fsm,
-              {clocksi_interactive_tx_coord_fsm, start_link, []},
-              transient, 5000, worker, [clocksi_interactive_tx_coord_fsm]},
-    lager:info("clockSI_interactive_tx_coord_sup: done."),
-    {ok, {{simple_one_for_one, 5, 10}, [Worker]}}.
+    Pool = [generate_supervisor_spec(N) || N <- lists:seq(1, ?NUM)],
+    {ok, {{one_for_one, 5, 10}, Pool}}.

--- a/src/clocksi_interactive_tx_coord_worker_sup.erl
+++ b/src/clocksi_interactive_tx_coord_worker_sup.erl
@@ -18,36 +18,21 @@
 %%
 %% -------------------------------------------------------------------
 
--module(clocksi_static_tx_coord_sup).
+-module(clocksi_interactive_tx_coord_worker_sup).
 -author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
 
 -behavior(supervisor).
 
--export([start_fsm/1,
-         start_link/0]).
+-export([start_link/1]).
 
 -export([init/1]).
 
--define(NUM, 100).
-
-start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
-
-start_fsm(Args) ->
-    Random = random:uniform(?NUM),
-    Module = generate_module_name(Random),
-    supervisor:start_child(Module, Args).
-
-generate_module_name(N) ->
-    list_to_atom(atom_to_list(?MODULE) ++ "-" ++ integer_to_list(N)).
-
-generate_supervisor_spec(N) ->
-    Module = generate_module_name(N),
-    {Module,
-     {clocksi_static_tx_coord_worker_sup, start_link, [Module]},
-      permanent, 5000, worker, [clocksi_static_tx_coord_worker_sup]}.
+start_link(Name) ->
+    supervisor:start_link({local, Name}, ?MODULE, []).
 
 %% @doc Starts the coordinator of a ClockSI static transaction.
 init([]) ->
-    Pool = [generate_supervisor_spec(N) || N <- lists:seq(1, ?NUM)],
-    {ok, {{one_for_one, 5, 10}, Pool}}.
+    Worker = {undefined,
+              {clocksi_interactive_tx_coord_fsm, start_link, []},
+               temporary, 5000, worker, [clocksi_interactive_tx_coord_fsm]},
+    {ok, {{simple_one_for_one, 5, 10}, [Worker]}}.

--- a/src/clocksi_static_tx_coord_fsm.erl
+++ b/src/clocksi_static_tx_coord_fsm.erl
@@ -70,6 +70,7 @@ start_link(From, Operations) ->
 
 %% @doc Initialize the state.
 init([From, ClientClock, Operations]) ->
+    _ = random:seed(erlang:now()),
     {ok, _Pid} = case ClientClock of
                      ignore ->
                          clocksi_interactive_tx_coord_sup:start_fsm([self()]);

--- a/src/clocksi_static_tx_coord_sup.erl
+++ b/src/clocksi_static_tx_coord_sup.erl
@@ -33,9 +33,7 @@ start_fsm(Args) ->
 
 %% @doc Starts the coordinator of a ClockSI static transaction.
 init([]) ->
-    lager:info("clockSI_static_tx_coord_sup: Starting fsm..."),
-    Worker = {clocksi_static_tx_coord_fsm,
+    Worker = {undefined,
               {clocksi_static_tx_coord_fsm, start_link, []},
-              transient, 5000, worker, [clocksi_static_tx_coord_fsm]},
-    lager:info("clockSI_static_tx_coord_sup: done."),
+               temporary, 5000, worker, [clocksi_static_tx_coord_fsm]},
     {ok, {{simple_one_for_one, 5, 10}, [Worker]}}.

--- a/src/clocksi_static_tx_coord_worker_sup.erl
+++ b/src/clocksi_static_tx_coord_worker_sup.erl
@@ -18,35 +18,21 @@
 %%
 %% -------------------------------------------------------------------
 
--module(clocksi_static_tx_coord_sup).
+-module(clocksi_static_tx_coord_worker_sup).
 -author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
 
 -behavior(supervisor).
 
--export([start_fsm/1,
-         start_link/0]).
+-export([start_link/1]).
 
 -export([init/1]).
 
--define(NUM, 100).
-
-start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
-
-start_fsm(Args) ->
-    Module = generate_module_name(random:uniform(?NUM)),
-    supervisor:start_child(Module, Args).
-
-generate_module_name(N) ->
-    list_to_atom(atom_to_list(?MODULE) ++ "-" ++ integer_to_list(N)).
-
-generate_supervisor_spec(N) ->
-    Module = generate_module_name(N),
-    {Module,
-     {clocksi_static_tx_coord_worker_sup, start_link, [Module]},
-      permanent, 5000, worker, [clocksi_static_tx_coord_worker_sup]}.
+start_link(Name) ->
+    supervisor:start_link({local, Name}, ?MODULE, []).
 
 %% @doc Starts the coordinator of a ClockSI static transaction.
 init([]) ->
-    Pool = [generate_supervisor_spec(N) || N <- lists:seq(1, ?NUM)],
-    {ok, {{one_for_one, 5, 10}, Pool}}.
+    Worker = {undefined,
+              {clocksi_static_tx_coord_fsm, start_link, []},
+               temporary, 5000, worker, [clocksi_static_tx_coord_fsm]},
+    {ok, {{simple_one_for_one, 5, 10}, [Worker]}}.


### PR DESCRIPTION
Use a pool of supervisors to balance connections on; this eliminates the
serialization point at the supervisor for starting children, which was
always seen having a ~200ish backlog of messages under our profiling
workload.