### PR TITLE
Address incorrect function call.

### DIFF
--- a/src/antidote_pb_set.erl
+++ b/src/antidote_pb_set.erl
@@ -67,7 +67,7 @@ process(#fpbsetupdatereq{key=Key, adds=AddsBin, rems=RemsBin}, State) ->
                                     Error+1
                             end
                             end, 0, AddsBin),
-    NumError2 = lists:foreach(fun(X, Error) ->
+    NumError2 = lists:foldl(fun(X, Error) ->
                             Elem = erlang:binary_to_term(X),
                             case antidote:append(Key, riak_dt_orset, {{remove, Elem}, node()}) of
                                 {ok, _} ->


### PR DESCRIPTION
antidote_pb_set.erl:70: Call to missing or unexported function lists:foreach/3

lists:foreach/3 doesn't exist; this call is supposed to technically be a
lists:foldl, however, it's unclear if we have any coverage for this
function at all, given none of the existing tests generated an error
with this call.