### PR TITLE
Evaluation materializer fix

### DIFF
--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -67,7 +67,7 @@
 -type partition_id()  :: non_neg_integer().
 -type log_id() :: [partition_id()].
 -type type() :: atom().
--type snapshot() :: term().
+-type snapshot() :: crdt().
 -type snapshot_time() ::  vectorclock:vectorclock().
 -type commit_time() ::  {term(), non_neg_integer()}.
 -type txid() :: #tx_id{}.

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -69,7 +69,7 @@
 -type type() :: atom().
 -type snapshot() :: crdt().
 -type snapshot_time() ::  vectorclock:vectorclock().
--type commit_time() ::  {term(), non_neg_integer()}.
+-type commit_time() ::  {dcid(), non_neg_integer()}.
 -type txid() :: #tx_id{}.
 -type clocksi_payload() :: #clocksi_payload{}.
 -type dcid() :: term().

--- a/src/clocksi_materializer.erl
+++ b/src/clocksi_materializer.erl
@@ -37,20 +37,14 @@ new(Type) ->
 
 
 %% @doc Calls the internal function materialize/6, with no TxId.
+%% FIXME: Documentation!
 -spec materialize(type(), snapshot(),
 					  SnapshotCommitTime::{dcid(),CommitTime::non_neg_integer()} | ignore,
                       snapshot_time(), 
                       [clocksi_payload()], txid()) -> {ok, snapshot(), 
                       {dcid(),CommitTime::non_neg_integer()} | ignore} | {error, term()}.
-%materialize(_Type, Snapshot, _SnapshotTime, []) ->
-%    {ok, Snapshot};
 materialize(Type, Snapshot, SnapshotCommitTime, SnapshotTime, Ops, TxId) ->
-    case materialize(Type, Snapshot, SnapshotCommitTime, SnapshotTime, Ops, TxId, SnapshotCommitTime) of
-    {ok, Val, CommitTime} ->
-    	{ok, Val, CommitTime};
-    {error, Reason} ->
-    	{error, Reason}
-    end.
+    materialize(Type, Snapshot, SnapshotCommitTime, SnapshotTime, Ops, TxId, SnapshotCommitTime).
 
 
 

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -175,18 +175,22 @@ handle_command({read_from, LogId, _From}, _Sender,
                #state{partition=Partition, logs_map=Map, last_read=Lastread}=State) ->
     case get_log_from_map(Map, Partition, LogId) of
         {ok, Log} ->
-            disk_log:sync(Log),
-            {Continuation, Ops} = 
-                case disk_log:chunk(Log, Lastread) of
-                    {error, Reason} -> {error, Reason};
-                    {C, O} -> {C,O};
-                    {C, O, _} -> {C,O};
-                    eof -> {eof, []}
-                end,
-            case Continuation of
-                error -> {reply, {error, Ops}, State};
-                eof -> {reply, {ok, Ops}, State};
-                _ -> {reply, {ok, Ops}, State#state{last_read=Continuation}}
+            case disk_log:sync(Log) of
+                ok ->
+                    {Continuation, Ops} = 
+                    case disk_log:chunk(Log, Lastread) of
+                        {error, Reason} -> {error, Reason};
+                        {C, O} -> {C,O};
+                        {C, O, _} -> {C,O};
+                        eof -> {eof, []}
+                    end,
+                    case Continuation of
+                        error -> {reply, {error, Ops}, State};
+                        eof -> {reply, {ok, Ops}, State};
+                        _ -> {reply, {ok, Ops}, State#state{last_read=Continuation}}
+                    end;
+                _ ->
+                    {reply, {error, disklog_write_failed}, State}
             end;
         {error, Reason} ->
             {reply, {error, Reason}, State}

--- a/src/materializer.erl
+++ b/src/materializer.erl
@@ -33,7 +33,7 @@ create_snapshot(Type) ->
     Type:new().
 
 %% @doc Applies all the operations of key from a list of log entries to a CRDT.
--spec update_snapshot(key(), type(), snapshot(), [op]) -> snapshot() | {error,unexpected_format,op()}.
+-spec update_snapshot(key(), type(), snapshot(), [op()]) -> snapshot() | {error,unexpected_format,op()}.
 update_snapshot(_, _, Snapshot, []) ->
     Snapshot;
 update_snapshot(Key, Type, Snapshot, [LogEntry|Rest]) ->

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -61,7 +61,7 @@ start_vnode(I) ->
     riak_core_vnode_master:get_vnode_pid(I, ?MODULE).
 
 %% @doc Read state of key at given snapshot time
-%% FIXME: What does this actually return???
+%% @todo What does this actually return???
 -spec read(key(), type(), snapshot_time(), txid()) -> {ok, term()} | {error, reason()}.
 read(Key, Type, SnapshotTime, TxId) ->
     DocIdx = riak_core_util:chash_key({?BUCKET, term_to_binary(Key)}),
@@ -153,7 +153,7 @@ terminate(_Reason, _State) ->
 
 %% @doc This function takes care of reading. It is implemented here for not blocking the
 %% vnode when the write function calls it. That is done for garbage collection.
-% FIXME: Better description + what is returned???
+%% @todo Better description + what is returned???
 -spec internal_read(pid() | ignore, key(), type(), snapshot_time(), txid() | ignore, ets:tid() , ets:tid() ) -> {ok, term()} | {error, no_snapshot}.
 internal_read(Sender, Key, Type, SnapshotTime, TxId, OpsCache, SnapshotCache) ->
     case ets:lookup(SnapshotCache, Key) of


### PR DESCRIPTION
Simplified type annotations by using types defined in antidote.hrl.
Simplified the filter_ops function by using a simple lists:map.
Simplified the is_op_in_snapshot function by rearranging the boolean
expressions.