### PR TITLE
Fix abort message crashing interactive_coord_fsm

### DIFF
--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -225,6 +225,8 @@ abort(abort, SD0=#state{transaction=Transaction,
 
 %% @doc when the transaction has committed or aborted,
 %%       a reply is sent to the client that started the transaction.
+reply_to_client(abort, SD) ->
+    reply_to_client(timeout, SD);
 reply_to_client(timeout, SD=#state{from=From, transaction=Transaction, state=TxState, commit_time=CommitTime}) ->
     case undefined =/= From of
         true ->


### PR DESCRIPTION
An interactive txn that updates several keys can get aborted and receives several abort message.
In the current, as soon as it receives the first abort, it will transfer to reply_to_client state, as follows:
{next_state, reply_to_client, SD0#state{state=aborted},0};

So reply_to_client state is supposed to receive timeout message and start. However, it can receive other abort messages, which is not expected by the state, and the fsm will crash. So the fix is to add another event to trigger reply_to_client: if reply_to_client receives abort, it will proceed as if receives timeout.
