### PR TITLE
Add mock partition fsm and add macro to clocksi_interactive_coord_fsm

### DIFF
--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -342,6 +342,7 @@ main_test_() ->
      [
       fun empty_prepare_test/1,
       fun timeout_test/1,
+
       fun update_single_abort_test/1,
       fun update_single_success_test/1,
       fun update_multi_abort_test1/1,

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -67,7 +67,7 @@ start_link() ->
 init([]) ->
     {ok, execute_op, #state{}}.
 
-%% Functions that always behave the same no matte the input.
+%% Functions that always return the same value no matte the input.
 get_my_dc_id() ->
     mock_dc.
 
@@ -87,7 +87,7 @@ abort(_UpdatedPartitions, _Transactions) ->
 commit(_UpdatedPartitions, _Transaction, _CommitTime) ->
     ok.
 
-%% Functions that will return different value depending on key.
+%% Functions that will return different value depending on Key.
 read_data_item(_IndexNode, _Transaction, Key, _Type) ->
     case Key of 
         read_fail ->
@@ -111,8 +111,10 @@ prepare(UpdatedPartitions, _Transaction) ->
     Self = self(),
     lists:foreach(fun(Fsm) -> gen_fsm:send_event(Fsm, {prepare, Self}) end, UpdatedPartitions).
 
-%% We spawn a new mock_partition_fsm for each update/read request, therefore
-%% a mock fsm can only have one key.
+%% We spawn a new mock_partition_fsm for each update request, therefore
+%% a mock fsm will only receive a single update so only need to store a 
+%% single updated key. In contrast, clocksi_vnode may receive multiple
+%% update request for a single transaction.
 execute_op({update_data_item, Key}, _From, State) ->
     Result = case Key of 
                 fail_update ->

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -1,0 +1,151 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc A mocked file that emulates the behavior of several antidote 
+%%      components which relies on riak-core backend, e.g. 
+%%      clocksi_vnode, dc_utilities and log_utilities. For simplicity,
+%%      the reply of some functions depend on the key being updated.
+%%      The detailed usage can be checked within each function, which is
+%%      self-explanatory.
+
+-module(mock_partition_fsm).
+
+-include("antidote.hrl").
+
+%% API
+-export([start_link/0]).
+
+%% Callbacks
+-export([init/1,
+         execute_op/3,
+         execute_op/2,
+         code_change/4,
+         handle_event/3,
+         handle_info/3,
+         handle_sync_event/4,
+         terminate/3]).
+
+-export([get_my_dc_id/0, 
+        get_clock_of_dc/2, 
+        get_preflist_from_key/1,
+        read_data_item/4,
+        generate_downstream_op/5,
+        update_data_item/5,
+        prepare/2,
+        abort/2,
+        commit/3,
+        get_stable_snapshot/0
+        ]).
+
+-record(state, {
+        key :: atom()}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_fsm:start_link(?MODULE, [], []).
+
+%% @doc Initialize the state.
+init([]) ->
+    {ok, execute_op, #state{}}.
+
+%% Functions that always behave the same no matte the input.
+get_my_dc_id() ->
+    mock_dc.
+
+get_clock_of_dc(_DcId, _SnapshotTime) ->
+    {ok, 0}.
+
+get_preflist_from_key(_Key) ->
+    {ok, Pid} = mock_fsm_tester:start_link(),
+    [Pid].
+
+get_stable_snapshot() ->
+    {ok, dict:new()}.
+
+abort(_UpdatedPartitions, _Transactions) ->
+    ok.
+
+commit(_UpdatedPartitions, _Transaction, _CommitTime) ->
+    ok.
+
+%% Functions that will return different value depending on key.
+read_data_item(_IndexNode, _Transaction, Key, _Type) ->
+    case Key of 
+        read_fail ->
+            {error, mock_read_fail};
+        _ ->
+            {ok, mock_value}
+    end.
+
+generate_downstream_op(_Transaction, _IndexNode, Key, _Type, _Param) ->
+    case Key of 
+        downstream_fail ->
+            {error, mock_downstream_fail};
+        _ ->
+            {ok, mock_downsteam}
+    end.
+
+update_data_item(FsmRef, _Transaction, Key, _Type, _DownstreamRecord) ->
+    gen_fsm:sync_send_event(FsmRef, {update_data_item, Key}).
+
+prepare(UpdatedPartitions, _Transaction) ->
+    Self = self(),
+    lists:foreach(fun(Fsm) -> gen_fsm:send_event(Fsm, {prepare, Self}) end, UpdatedPartitions).
+
+%% We spawn a new mock_partition_fsm for each update/read request, therefore
+%% a mock fsm can only have one key.
+execute_op({update_data_item, Key}, _From, State) ->
+    Result = case Key of 
+                fail_update ->
+                    {error, mock_downstream_fail};
+                _ ->
+                    ok
+            end,
+    {reply, Result, execute_op, State#state{key=Key}}.
+
+execute_op({prepare,From}, State=#state{key=Key}) ->
+    Result = case Key of 
+                success -> {prepared, 10};
+                timeout -> timeout;
+                _ -> abort
+            end,
+    gen_fsm:send_event(From, Result),
+    {stop, normal, State}.
+
+%% =====================================================================
+handle_info(_Info, _StateName, StateData) ->
+    {stop,badmsg,StateData}.
+
+handle_event(_Event, _StateName, StateData) ->
+    {stop,badmsg,StateData}.
+
+handle_sync_event(stop,_From,_StateName, StateData) ->
+    {stop,normal,ok, StateData};
+
+handle_sync_event(_Event, _From, _StateName, StateData) ->
+    {stop,badmsg,StateData}.
+
+code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
+
+terminate(_Reason, _SN, _SD) ->
+    ok.
+

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -48,6 +48,7 @@
         generate_downstream_op/5,
         update_data_item/5,
         prepare/2,
+        value/1,
         abort/2,
         commit/3,
         get_stable_snapshot/0
@@ -67,9 +68,12 @@ start_link() ->
 init([]) ->
     {ok, execute_op, #state{}}.
 
-%% Functions that always return the same value no matte the input.
+%% Functions that always return the same value no matter the input.
 get_my_dc_id() ->
     mock_dc.
+
+value(_) ->
+    mock_value.
 
 get_clock_of_dc(_DcId, _SnapshotTime) ->
     {ok, 0}.
@@ -92,6 +96,15 @@ read_data_item(_IndexNode, _Transaction, Key, _Type) ->
     case Key of 
         read_fail ->
             {error, mock_read_fail};
+        counter ->
+            Counter = riak_dt_gcounter:new(),
+            {ok, Counter1} = riak_dt_gcounter:update(increment, haha, Counter),
+            {ok, Counter2} = riak_dt_gcounter:update(increment, nono, Counter1),
+            {ok, Counter2};
+        set ->
+            Set = riak_dt_gset:new(),
+            {ok, Set1} = riak_dt_gset:update({add, a}, haha, Set),
+            {ok, Set1}; 
         _ ->
             {ok, mock_value}
     end.

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -75,7 +75,7 @@ get_clock_of_dc(_DcId, _SnapshotTime) ->
     {ok, 0}.
 
 get_preflist_from_key(_Key) ->
-    {ok, Pid} = mock_fsm_tester:start_link(),
+    {ok, Pid} = mock_partition_fsm:start_link(),
     [Pid].
 
 get_stable_snapshot() ->


### PR DESCRIPTION
I added some macro definition to clocksi_interactive_coord_fsm so that some components can be easily replaced. This enables testing the state transition of clocksi_interactive_coord_fsm by EUnit test in a light way.

As for bug fix, I changed reply_to_client from a state to a function. I also found a bug that, in abort state, the fsm may receive prepare message, which is not expected, and that will crash the fsm. Now the message is handled in abort state.