### PR TITLE
Small fixes in inter_dc update propagation

### DIFF
--- a/src/antidote_sup.erl
+++ b/src/antidote_sup.erl
@@ -92,6 +92,11 @@ init(_Args) ->
                            [materializer_vnode]},
                           permanent, 5000, worker, [riak_core_vnode_master]},
 
+    InterDcSenderSup = {inter_dc_communication_sender_fsm_sup,
+    		      {inter_dc_communication_sender_fsm_sup, start_link, []},
+    		      permanent, 5000, supervisor,
+    		      [inter_dc_communication_sender_fsm_sup]},
+
     InterDcManager = {inter_dc_manager,
                         {inter_dc_manager, start_link, []},
                         permanent, 5000, worker, [inter_dc_manager]},
@@ -106,4 +111,5 @@ init(_Args) ->
        InterDcRecvrMaster,
        InterDcManager,
        VectorClockMaster,
+       InterDcSenderSup,
        MaterializerMaster]}}.

--- a/src/inter_dc_communication_fsm.erl
+++ b/src/inter_dc_communication_fsm.erl
@@ -62,7 +62,12 @@ receive_message(timeout, State=#state{socket=Socket}) ->
             case binary_to_term(Message) of
                 {replicate, Updates} ->
                     ok =  inter_dc_recvr_vnode:store_updates(Updates) ,
-                    ok = gen_tcp:send(Socket, term_to_binary(acknowledge));
+                    case gen_tcp:send(Socket, term_to_binary(acknowledge)) of
+			ok ->
+			    ok;
+			{error,Reason} ->
+			    lager:error("Could not send ack, reason ~p", [Reason])
+		    end;
                 Unknown -> %% Add more messages to be handled
                     lager:error("Weird message received ~p", [Unknown])
             end;

--- a/src/inter_dc_communication_sender.erl
+++ b/src/inter_dc_communication_sender.erl
@@ -117,10 +117,12 @@ wait_for_ack(acknowledge, State)->
 wait_for_ack(timeout, State) ->
     %%TODO: Retry if needed
     lager:error("Timeout in wait for ACK",[]),
+    %% Retry after timeout is handled in the propagate_sync loop above
+    %% So the fsm returns a normal stop so that it isn't restarted by the supervisor
     {next_state,stop_error,State#state{reason=timeout},0}.
 
 stop(timeout, State=#state{socket=Socket}) ->
-    _ = gen_tcp:close(Socket),
+    _ = gen_tcp:close(Socket), 
     {stop, normal, State}.
 
 stop_error(timeout, State=#state{socket=Socket}) ->

--- a/src/inter_dc_communication_sender.erl
+++ b/src/inter_dc_communication_sender.erl
@@ -40,10 +40,9 @@
          stop_error/2
         ]).
 
--record(state, {port, host, socket,message, caller}). % the current socket
+-record(state, {port, host, socket,message, caller, reason}). % the current socket
 
--define(TIMEOUT,20000).
--define(CONNECT_TIMEOUT,5000).
+-define(CONNECT_TIMEOUT,20000).
 
 %% ===================================================================
 %% Public API
@@ -55,8 +54,8 @@
 propagate_sync(Message, DCs) ->
     FailedDCs = lists:foldl(
                fun({DcId, {DcAddress, Port}}, Acc) ->
-                       case inter_dc_communication_sender:start_link(
-                              Port, DcAddress, Message, self()) of
+                       case inter_dc_communication_sender_fsm_sup:start_fsm(
+                              [Port, DcAddress, Message, self()]) of
                            {ok, _} ->
                                receive
                                    {done, normal} ->
@@ -65,20 +64,13 @@ propagate_sync(Message, DCs) ->
                                        lager:error(
                                          "Send failed Reason:~p Message: ~p",
                                          [Other, Message]),
-                                       Acc ++ [{DcAddress,Port}]
-                                       %%TODO: Retry if needed
-                               after ?TIMEOUT ->
-                                       lager:error(
-                                         "Send failed timeout Message ~p"
-                                         ,[Message]),
                                        Acc ++ [{DcId, {DcAddress,Port}}]
-                                       %%TODO: Retry if needed
-                               end;
+			       end;
                            _ ->
                                Acc ++ [{DcId, {DcAddress,Port}}]
                        end
                end, [],
-               DCs),
+		  DCs),
     case length(FailedDCs) of
         0 ->
             ok;
@@ -116,15 +108,16 @@ connect(timeout, State=#state{port=Port,host=Host,message=Message}) ->
             {next_state, wait_for_ack, State#state{socket=Socket},?CONNECT_TIMEOUT};
         {error, Reason} ->
             lager:error("Couldnot connect to remote DC: ~p", [Reason]),
-            {next_state, stop_error, State}
+            {stop, normal, State#state{reason=Reason}}
     end.
 
 wait_for_ack(acknowledge, State)->
-    {next_state, stop, State,0};
+    {next_state, stop, State#state{reason=normal},0};
 
 wait_for_ack(timeout, State) ->
     %%TODO: Retry if needed
-    {next_state,stop_error,State,0}.
+    lager:error("Timeout in wait for ACK",[]),
+    {next_state,stop_error,State#state{reason=timeout},0}.
 
 stop(timeout, State=#state{socket=Socket}) ->
     _ = gen_tcp:close(Socket),
@@ -132,7 +125,7 @@ stop(timeout, State=#state{socket=Socket}) ->
 
 stop_error(timeout, State=#state{socket=Socket}) ->
     _ = gen_tcp:close(Socket),
-    {stop, error, State}.
+    {stop, normal, State}.
 
 %% Converts incoming tcp message to an fsm event to self
 handle_info({tcp, Socket, Bin}, StateName, #state{socket=Socket} = StateData) ->
@@ -156,6 +149,6 @@ handle_sync_event(_Event, _From, _StateName, StateData) ->
 
 code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
 
-terminate(Reason, _SN, _State = #state{caller = Caller}) ->
-    Caller ! {done, Reason},
+terminate(_Reason, _SN, _State = #state{caller = Caller, reason=Res}) ->
+    Caller ! {done, Res},
     ok.

--- a/src/inter_dc_communication_sender_fsm_sup.erl
+++ b/src/inter_dc_communication_sender_fsm_sup.erl
@@ -1,0 +1,41 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc Supervise the fsm.
+-module(inter_dc_communication_sender_fsm_sup).
+-behavior(supervisor).
+
+-export([start_fsm/1,
+         start_link/0]).
+-export([init/1]).
+
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+
+start_fsm(Args) ->
+    supervisor:start_child(?MODULE, Args).
+
+
+init([]) ->
+    Worker = {inter_dc_communication_sender,
+              {inter_dc_communication_sender, start_link, []},
+              transient, 5000, worker, [inter_dc_communication_sender]},
+    {ok, {{simple_one_for_one, 5, 10}, [Worker]}}.

--- a/src/inter_dc_repl_vnode.erl
+++ b/src/inter_dc_repl_vnode.erl
@@ -46,7 +46,7 @@
                 reader}).
 
 %% REPL_PERIOD: Frequency of checking new transactions and sending to other DC
--define(REPL_PERIOD, 5000).
+-define(REPL_PERIOD, 10000).
 
 start_vnode(I) ->
     {ok, Pid} = riak_core_vnode_master:get_vnode_pid(I, ?MODULE),


### PR DESCRIPTION
This branch has a few fixes to the inter_dc update propagation.

First instead of creating an fsm directly in the sender, it uses a supervisor.  This way it doesn't have to use an fsm timeout on top of a connection timeout, because now if the fsm crashes the supervisor will restart it.

Also  on line 68 of src/inter_dc_communication_sender.erl an incorrect structure for the tuple was being used which caused a crash on line 57 in case of a timeout.  This is no longer needed because the supervisor is used.

Also slowed down the replication period/connection timeout, which before was creating cascading timeouts, this should make the tests more stable.  It is not a solution though, because the replication period should be much smaller in the first place, but since the inter dc replication system will be changed to use pub/sub this should be suitable for now.