### PR TITLE
Check prepared time without blocking reads

### DIFF
--- a/src/clocksi_transaction_reader.erl
+++ b/src/clocksi_transaction_reader.erl
@@ -195,22 +195,11 @@ get_sorted_commit_records(Commitrecords) ->
 %% @doc Return smallest snapshot time of active transactions.
 %%      No new updates with smaller timestamp will occur in future.
 get_stable_time(Partition, Prev_stable_time) ->
-    case clocksi_vnode:get_active_txns(
-	   Partition, clocksi_vnode:get_cache_name(Partition,prepared)) of
-        {ok, Active_txns} ->
-            lists:foldl(fun({_TxId, Snapshot_time}, Min_time) ->
-                                case Min_time > Snapshot_time of
-                                    true ->
-                                        Snapshot_time;
-                                    false ->
-                                        Min_time
-                                end
-                        end,
-                        clocksi_vnode:now_microsec(erlang:now()),
-                        Active_txns);
+    case clocksi_vnode:get_min_prepared(Partition) of
+        {ok, Time} ->
+	    Time;
         _ -> Prev_stable_time
     end.
-
 
 %%@doc Add updates in writeset ot Pending operations to process downstream
 add_to_pending_operations(Pending, Commitrecords, Ops, DcId) ->

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -70,7 +70,7 @@
     prepared_tx :: cache_id(),
     committed_tx :: cache_id(),
     read_servers :: non_neg_integer(),
-    prepared_dict}).
+    prepared_dict :: list()}).
 
 %%%===================================================================
 %%% API
@@ -624,7 +624,7 @@ reverse_and_filter_updates_per_key(Updates, Key) ->
 		end, [], Updates).
 
 
-%%-spec get_min(orddict()) -> non_neg_integer().		   
+-spec get_min_prep(list()) -> {ok, non_neg_integer()}.
 get_min_prep(OrdDict) ->
     case OrdDict of
 	[] ->
@@ -633,7 +633,7 @@ get_min_prep(OrdDict) ->
 	    {ok, Time}
     end.
 
-%%-spec get_time(orddict(),txid()) -> non_neg_integer().
+-spec get_time(list(),txid()) -> {ok, non_neg_integer()} | error.
 get_time([],_TxIdCheck) ->
     error;
 get_time([{Time,TxId} | Rest], TxIdCheck) ->


### PR DESCRIPTION
In antidote when there have been no updates for a certain period of time, a heartbeat is sent.  The time for the heartbeat has to have a time smaller than any transactions that might commit in the future on this partition.  Because of this, the node that sends the heartbeats has to check with the clocksi_vnode incase a transaction is being prepared that might get a smaller commit time.

Previously this was done by taking the ets table that stored the prepared transactions and changing it to a list then taking the minimum.  The problem with this is that doing this was that the ets:tab_to_list operation was blocking concurrent readers and becoming a bottleneck when there were multiple DCs heartbeats had to be sent often.  Now this information is just stored in the clocksi_vnode directly, so concurrent reads don't have to be blocked, instead writes will be blocked but only for the time it takes to read the head of the list.  Also this only happens when there have been no writes recently so this shouldn't be a problem.