### PR TITLE
Materialiser fixes

### DIFF
--- a/riak_test/common.erl
+++ b/riak_test/common.erl
@@ -20,8 +20,7 @@
 -module(common).
 
 -export([clean_clusters/1,
-         setup_dc_manager/3,
-	 setup_dc_manager_no_rt/3]).
+         setup_dc_manager/3]).
 
 %% It cleans the cluster and formes a new one with the same characteristic of the input one.
 %% In case the clean_cluster parameter is set to false in the riak_test configuration file
@@ -60,29 +59,6 @@ setup_dc_manager(Clusters, Ports, Clean) ->
                                     rt:wait_until_registered(Node, inter_dc_manager),
                                     {ok, DC} = rpc:call(Node, inter_dc_manager, start_receiver,[Port]),
                                     rt:wait_until(Node,fun wait_init:check_ready/1),
-                                    Acc ++ [{Node, DC}]
-                                end, [], CombinedList),
-            lists:foreach(fun({Node, DC}) ->
-                            Sublist = lists:subtract(Heads, [{Node, DC}]),
-                            lists:foreach(fun({_, RemoteDC}) ->
-                                            ok = rpc:call(Node, inter_dc_manager, add_dc,[RemoteDC])
-                                          end, Sublist)
-                          end, Heads),
-            ok;
-        false ->
-            ok
-    end.
-
-
-setup_dc_manager_no_rt(Clusters, Ports, Clean) ->
-    case Clean of
-        true ->
-            {_, CombinedList} = lists:foldl(fun(Cluster, {Index, Result}) ->
-                                                {Index+1, Result ++ [{Cluster, lists:nth(Index, Ports)}]}
-                                            end, {1, []}, Clusters),
-            Heads = lists:foldl(fun({Cluster, Port}, Acc) ->
-                                    Node = hd(Cluster),
-                                    {ok, DC} = rpc:call(Node, inter_dc_manager, start_receiver,[Port]),
                                     Acc ++ [{Node, DC}]
                                 end, [], CombinedList),
             lists:foreach(fun({Node, DC}) ->

--- a/riak_test/common.erl
+++ b/riak_test/common.erl
@@ -20,7 +20,8 @@
 -module(common).
 
 -export([clean_clusters/1,
-         setup_dc_manager/3]).
+         setup_dc_manager/3,
+	 setup_dc_manager_no_rt/3]).
 
 %% It cleans the cluster and formes a new one with the same characteristic of the input one.
 %% In case the clean_cluster parameter is set to false in the riak_test configuration file
@@ -59,6 +60,29 @@ setup_dc_manager(Clusters, Ports, Clean) ->
                                     rt:wait_until_registered(Node, inter_dc_manager),
                                     {ok, DC} = rpc:call(Node, inter_dc_manager, start_receiver,[Port]),
                                     rt:wait_until(Node,fun wait_init:check_ready/1),
+                                    Acc ++ [{Node, DC}]
+                                end, [], CombinedList),
+            lists:foreach(fun({Node, DC}) ->
+                            Sublist = lists:subtract(Heads, [{Node, DC}]),
+                            lists:foreach(fun({_, RemoteDC}) ->
+                                            ok = rpc:call(Node, inter_dc_manager, add_dc,[RemoteDC])
+                                          end, Sublist)
+                          end, Heads),
+            ok;
+        false ->
+            ok
+    end.
+
+
+setup_dc_manager_no_rt(Clusters, Ports, Clean) ->
+    case Clean of
+        true ->
+            {_, CombinedList} = lists:foldl(fun(Cluster, {Index, Result}) ->
+                                                {Index+1, Result ++ [{Cluster, lists:nth(Index, Ports)}]}
+                                            end, {1, []}, Clusters),
+            Heads = lists:foldl(fun({Cluster, Port}, Acc) ->
+                                    Node = hd(Cluster),
+                                    {ok, DC} = rpc:call(Node, inter_dc_manager, start_receiver,[Port]),
                                     Acc ++ [{Node, DC}]
                                 end, [], CombinedList),
             lists:foreach(fun({Node, DC}) ->

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -296,7 +296,7 @@ handle_command({get, LogId, MinSnapshotTime, Type, Key}, _Sender,
                 {error, Reason} ->
                     {reply, {error, Reason}, State};
                 CommitedOpsForKey ->
-                    {reply, {length(CommitedOpsForKey), CommitedOpsForKey, clocksi_materializer:new(Type),
+                    {reply, {length(CommitedOpsForKey), CommitedOpsForKey, {0,clocksi_materializer:new(Type)},
                         vectorclock:new(), false}, State}
             end;
         {error, Reason} ->

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -253,7 +253,7 @@ internal_read(Key, Type, MinSnapshotTime, TxId, OpsCache, SnapshotCache) ->
 			     {LS,SCT,IsF}
 		     end
 	     end,
-    {Length,Ops,LatestSnapshot,SnapshotCommitTime,IsFirst} =
+    {Length,Ops,{LastOp,LatestSnapshot},SnapshotCommitTime,IsFirst} =
 	case Result of
 	    {error, no_snapshot} ->
 		LogId = log_utilities:get_logid_from_key(Key),
@@ -272,7 +272,7 @@ internal_read(Key, Type, MinSnapshotTime, TxId, OpsCache, SnapshotCache) ->
 	0 ->
 	    {ok, LatestSnapshot};
 	_Len ->
-	    case clocksi_materializer:materialize(Type, LatestSnapshot, SnapshotCommitTime, MinSnapshotTime, Ops, TxId) of
+	    case clocksi_materializer:materialize(Type, LatestSnapshot, LastOp, SnapshotCommitTime, MinSnapshotTime, Ops, TxId) of
 		{ok, Snapshot, NewLastOp, CommitTime, NewSS} ->
 		    %% the following checks for the case there were no snapshots and there were operations, but none was applicable
 		    %% for the given snapshot_time

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -91,7 +91,7 @@ insert_bigger_internal(Vector,Val,[],0) ->
     {[{Vector,Val}],1};
 
 insert_bigger_internal(Vector,Val,[{FirstClock,FirstVal}|Rest],Size) ->
-    case vectorclock:gt(Vector,FirstClock) of
+    case not vectorclock:le(Vector,FirstClock) of
 	true ->
 	    {[{Vector,Val}|[{FirstClock,FirstVal}|Rest]],Size+1};
 	false ->
@@ -157,7 +157,7 @@ vector_orddict_insert_bigger_test() ->
     Vdict1 = vector_orddict:insert_bigger(CT1, 1,Vdict0),
     ?assertEqual(1,vector_orddict:size(Vdict1)),
     %% Should not insert because smaller
-    CT2 = vectorclock:from_list([{dc1,3},{dc2,8}]),
+    CT2 = vectorclock:from_list([{dc1,3},{dc2,3}]),
     Vdict2 = vector_orddict:insert_bigger(CT2, 2, Vdict1),
     ?assertEqual(1,vector_orddict:size(Vdict2)),
     %% Should insert because bigger


### PR DESCRIPTION
This pull request aims to fix issues that could happen in the materialiser due to concurrency and cases where operations are executed before the DCs have connected fully connected and stabilised.

This pull request continues on the issues and fixes mentioned here:
https://github.com/SyncFree/antidote/issues/149
https://github.com/SyncFree/antidote/pull/150

The fix to the vector clock from https://github.com/SyncFree/antidote/pull/150 fixed certain cases, but there were still issues where operations could arrive to the materialiser from another DC with certain concurrency so that the snapshot would skip operations that should have been included.  The same could happen when garbage collecting the snapshots.  What I did to fix this was to simply assign an id number per key to each operation added to the materialiser, then when a new snapshot is generated from an old one, it will search all operations until the last one that was included by the previous snapshot.  Some unit tests have been added to check theses cases.  Note that this bug would also show up when running the inter_dc_rep_test, but only rarely, due to concurrency.  This pull request is a precursor to Michals pubsub changes as the bug is more apparent there.