### PR TITLE
config for erlang:now() vs os:timestamp()

### DIFF
--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -39,6 +39,10 @@
 %% At commit, if this is set to true, the logging vnode
 %% will ensure that the transaction record is written to disk
 -define(SYNC_LOG, false).
+%% Uncomment the following line to use erlang:now()
+%% Otherwise os:timestamp() is used which can go backwards
+%% which is unsafe for clock-si
+%% -define(SAFE_TIME, true).
 -record (payload, {key:: key(), type :: type(), op_param, actor}).
 %% Enalble or disable the certification check
 -ifdef(NO_CERTIFICATION).

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -42,7 +42,8 @@
 %% Uncomment the following line to use erlang:now()
 %% Otherwise os:timestamp() is used which can go backwards
 %% which is unsafe for clock-si
-%% -define(SAFE_TIME, true).
+-define(SAFE_TIME, true).
+
 -record (payload, {key:: key(), type :: type(), op_param, actor}).
 %% Enalble or disable the certification check
 -ifdef(NO_CERTIFICATION).

--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -116,7 +116,7 @@ init([From, ClientClock]) ->
 -spec create_transaction_record(snapshot_time() | ignore) -> {tx(), txid()}.
 create_transaction_record(ClientClock) ->
     %% Seed the random because you pick a random read server, this is stored in the process state
-    _Res = random:seed(now()),
+    _Res = random:seed(dc_utilities:now()),
     {ok, SnapshotTime} = case ClientClock of
                              ignore ->
                                  get_snapshot_time();
@@ -557,7 +557,7 @@ get_snapshot_time(ClientClock) ->
 
 -spec get_snapshot_time() -> {ok, snapshot_time()}.
 get_snapshot_time() ->
-    Now = clocksi_vnode:now_microsec(erlang:now()) - ?OLD_SS_MICROSEC,
+    Now = clocksi_vnode:now_microsec(dc_utilities:now()) - ?OLD_SS_MICROSEC,
     {ok, VecSnapshotTime} = ?VECTORCLOCK:get_stable_snapshot(),
     DcId = ?DC_UTIL:get_my_dc_id(),
     SnapshotTime = dict:update(DcId,
@@ -691,7 +691,7 @@ get_snapshot_time_test() ->
 wait_for_clock_test() ->
     {ok, SnapshotTime} = wait_for_clock(vectorclock:from_list([{mock_dc, 10}])),
     ?assertMatch([{mock_dc, _}], dict:to_list(SnapshotTime)),
-    VecClock = clocksi_vnode:now_microsec(now()),
+    VecClock = clocksi_vnode:now_microsec(dc_utilities:now()),
     {ok, SnapshotTime2} = wait_for_clock(vectorclock:from_list([{mock_dc, VecClock}])),
     ?assertMatch([{mock_dc, _}], dict:to_list(SnapshotTime2)).
 

--- a/src/clocksi_interactive_tx_coord_sup.erl
+++ b/src/clocksi_interactive_tx_coord_sup.erl
@@ -34,7 +34,7 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 start_fsm(Args) ->
-    _Res = random:seed(now()),
+    _Res = random:seed(dc_utilities:now()),
     Random = random:uniform(?NUM_SUP),
     Module = generate_module_name(Random),
     supervisor:start_child(Module, Args).

--- a/src/clocksi_readitem_fsm.erl
+++ b/src/clocksi_readitem_fsm.erl
@@ -198,7 +198,7 @@ perform_read_internal(Coordinator,Key,Type,Transaction,OpsCache,SnapshotCache,Pr
 check_clock(Key,Transaction,PreparedCache,Partition) ->
     TxId = Transaction#transaction.txn_id,
     T_TS = TxId#tx_id.snapshot_time,
-    Time = clocksi_vnode:now_microsec(erlang:now()),
+    Time = clocksi_vnode:now_microsec(dc_utilities:now()),
     case T_TS > Time of
         true ->
 	    {not_ready, (T_TS - Time) div 1000 +1};

--- a/src/clocksi_static_tx_coord_sup.erl
+++ b/src/clocksi_static_tx_coord_sup.erl
@@ -34,7 +34,7 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 start_fsm(Args) ->
-    _Res = random:seed(now()),
+    _Res = random:seed(dc_utilities:now()),
     Random = random:uniform(?NUM_SUP),
     Module = generate_module_name(Random),
     supervisor:start_child(Module, Args).

--- a/src/clocksi_updateitem_fsm.erl
+++ b/src/clocksi_updateitem_fsm.erl
@@ -58,7 +58,7 @@ init([Coordinator, VecSnapshotTime, Partition]) ->
 check_clock(timeout, SD0=#state{vclock=Vclock}) ->
     DcId = dc_utilities:get_my_dc_id(),
     {ok, T_TS} = vectorclock:get_clock_of_dc(DcId, Vclock),
-    Time = clocksi_vnode:now_microsec(erlang:now()),
+    Time = clocksi_vnode:now_microsec(dc_utilities:now()),
     Newclock = dict:erase(DcId, Vclock),
     case T_TS > Time of
         true ->

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -274,7 +274,7 @@ handle_command({prepare, Transaction, WriteSet}, _Sender,
         prepared_tx = PreparedTx,
 	prepared_dict = PreparedDict
     }) ->
-    PrepareTime = now_microsec(erlang:now()),
+    PrepareTime = now_microsec(dc_utilities:now()),
     {Result, NewPrepare, NewPreparedDict} = prepare(Transaction, WriteSet, CommittedTx, PreparedTx, PrepareTime, PreparedDict),
     case Result of
         {ok, _} ->
@@ -296,7 +296,7 @@ handle_command({single_commit, Transaction, WriteSet}, _Sender,
         prepared_tx = PreparedTx,
 	prepared_dict = PreparedDict
     }) ->
-    PrepareTime = now_microsec(erlang:now()),
+    PrepareTime = now_microsec(dc_utilities:now()),
     {Result, NewPrepare, NewPreparedDict} = prepare(Transaction, WriteSet, CommittedTx, PreparedTx, PrepareTime, PreparedDict),
     NewState = State#state{prepared_dict = NewPreparedDict},
     case Result of
@@ -423,7 +423,7 @@ prepare(Transaction, TxWriteSet, CommittedTx, PreparedTx, PrepareTime, PreparedD
             case TxWriteSet of
                 [{Key, _, {_Op, _Actor}} | _] ->
                     Dict = set_prepared(PreparedTx, TxWriteSet, TxId, PrepareTime, dict:new()),
-                    NewPrepare = now_microsec(erlang:now()),
+                    NewPrepare = now_microsec(dc_utilities:now()),
                     ok = reset_prepared(PreparedTx, TxWriteSet, TxId, NewPrepare, Dict),
 		    NewPreparedDict = orddict:store(NewPrepare, TxId, PreparedDict),
                     LogRecord = #log_record{tx_id = TxId,
@@ -641,7 +641,7 @@ reverse_and_filter_updates_per_key(Updates, Key) ->
 get_min_prep(OrdDict) ->
     case OrdDict of
 	[] ->
-	    {ok, clocksi_vnode:now_microsec(erlang:now())};
+	    {ok, clocksi_vnode:now_microsec(dc_utilities:now())};
 	[{Time,_TxId}|_] ->
 	    {ok, Time}
     end.

--- a/src/dc_utilities.erl
+++ b/src/dc_utilities.erl
@@ -19,8 +19,21 @@
 %% -------------------------------------------------------------------
 -module(dc_utilities).
 
--export([get_my_dc_id/0]).
+-export([get_my_dc_id/0,
+	 now/0]).
 
 get_my_dc_id() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     riak_core_ring:cluster_name(Ring).
+
+-ifdef(SAFE_TIME).
+
+now() ->
+    erlang:now().
+
+-else.
+
+now() ->
+    os:timestamp().
+
+-endif.

--- a/src/inter_dc_repl_update.erl
+++ b/src/inter_dc_repl_update.erl
@@ -77,7 +77,7 @@ process_q_dc(Dc, DcQ, StateData=#recvr_state{lastCommitted = LastCTS,
             Localclock = vectorclock:set_clock_of_dc(
                            Dc, 0,
                            vectorclock:set_clock_of_dc(
-                             LocalDc, now_millisec(erlang:now()), LC)),
+                             LocalDc, now_millisec(dc_utilities:now()), LC)),
             case orddict:find(Dc, LastCTS) of  % Check for duplicate
                 {ok, CTS} ->
                     if Ts >= CTS ->


### PR DESCRIPTION
This relates to the issue mentioned here
https://github.com/SyncFree/antidote/issues/151

erlang:now() is a well known scalability bottleneck, which is what we are currently using for clock si
os:timestamp() should scale, but can go backwards which makes clock si unsafe (rare but possible)

This branch is a temporary fix allowing you to use one or the other through a define in antidote.hrl

Eventually this will be fixed by upgrading to a new version of erlang that has the new timekeeping.