### PR TITLE
materialiser ets hacks

### DIFF
--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -355,7 +355,7 @@ clocksi_istart_tx(Clock, KeepAlive) ->
 	    end,
     _ = case TxPid of
 	undefined ->
-	    {ok, _} = clocksi_interactive_tx_coord_sup:start_fsm([self(), Clock, KeepAlive]);
+	    {ok, _} = clocksi_interactive_tx_coord_sup:start_fsm([self(), Clock, update_clock, KeepAlive]);
 	TxPid ->
 	    ok = gen_fsm:send_event(TxPid, {start_tx, self(), Clock})
     end,

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -280,8 +280,6 @@ internal_read(Key, Type, MinSnapshotTime, TxId, OpsCache, SnapshotCache,ShouldGc
 		    [Tuple] ->
 			[Key,Length1,_OpId|AllOps] = tuple_to_list(Tuple),
 			{Length1, sub_reverse(AllOps,Length1,[]), LatestSnapshot1, SnapshotCommitTime1, IsFirst1}
-			%% [{_, {Length1,Ops1}}] ->
-			%% 	{Length1,Ops1,LatestSnapshot1,SnapshotCommitTime1,IsFirst1}
 		end
 	end,
     case Length of
@@ -394,12 +392,6 @@ op_insert_gc(Key, DownstreamOp, OpsCache, SnapshotCache)->
     NewId = ets:update_counter(OpsCache, Key,
 			       {3,1}),
     Length = ets:lookup_element(OpsCache, Key, 2),
-    %% {Length,OpsDict,NewId} = case ets:lookup(OpsCache, Key) of
-    %% 				 []->
-    %% 				     {0,[],1};
-    %% 				 [{_, {Len,[{PrevId,First}|Rest]}}]->
-    %% 				     {Len,[{PrevId,First}|Rest],PrevId+1}
-    %% 		       end,
     case (Length)>=?OPS_THRESHOLD of
         true ->
             Type=DownstreamOp#clocksi_payload.type,
@@ -408,11 +400,8 @@ op_insert_gc(Key, DownstreamOp, OpsCache, SnapshotCache)->
 	    %% Have to get the new ops dict because the interal_read can change it
 	    Length1 = ets:lookup_element(OpsCache, Key, 2),
 	    true = ets:update_element(OpsCache, Key, [{Length1+4,{NewId,DownstreamOp}}, {2,Length1+1}]);
-            %% ets:insert(OpsCache, {Key, {Length1 + 1, OpsDict2}});
         false ->
 	    true = ets:update_element(OpsCache, Key, [{Length + 4, {NewId,DownstreamOp}}, {2,Length+1}])
-	    %% OpsDict1=[{NewId,DownstreamOp} | OpsDict],
-            %% ets:insert(OpsCache, {Key, {Length + 1,OpsDict1}})
     end.
 
 

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -355,7 +355,7 @@ snapshot_insert_gc(Key, SnapshotDict, SnapshotCache, OpsCache,ShouldGc)->
     end.
 
 %% @doc Remove from OpsDict all operations that have committed before Threshold.
--spec prune_ops({non_neg_integer(),list()}, snapshot_time())-> {non_neg_integer(),list()}.
+-spec prune_ops({non_neg_integer(),[any(),...]}, snapshot_time())-> {non_neg_integer(),[any(),...]}.
 prune_ops({_Len,OpsDict}, Threshold)->
 %% should write custom function for this in the vector_orddict
 %% or have to just traverse the entire list?

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -378,7 +378,7 @@ prune_ops({_Len,OpsDict}, Threshold)->
 op_insert_gc(Key, DownstreamOp, OpsCache, SnapshotCache)->
     case ets:member(OpsCache, Key) of
 	false ->
-	    ets:insert(OpsCache, erlang:make_tuple(3+?OPS_THRESHOLD,0,[{1,Key}]));
+	    ets:insert(OpsCache, erlang:make_tuple(4+?OPS_THRESHOLD,0,[{1,Key}]));
 	true ->
 	    ok
     end,

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -169,8 +169,9 @@ handle_command(_Message, _Sender, State) ->
 handle_handoff_command(?FOLD_REQ{foldfun=Fun, acc0=Acc0} ,
                        _Sender,
                        State = #state{ops_cache = OpsCache}) ->
-    F = fun({Key,Operation}, A) ->
-                Fun(Key, Operation, A)
+    F = fun(Key, A) ->
+		[Key1|_]=tuple_to_list(Key),
+                Fun(Key1, Key, A)
         end,
     Acc = ets:foldl(F, Acc0, OpsCache),
     {reply, Acc, State}.
@@ -185,8 +186,8 @@ handoff_finished(_TargetNode, State) ->
     {ok, State}.
 
 handle_handoff_data(Data, State=#state{ops_cache=OpsCache}) ->
-    {Key, Operation} = binary_to_term(Data),
-    true = ets:insert(OpsCache, {Key, Operation}),
+    {_Key, Operation} = binary_to_term(Data),
+    true = ets:insert(OpsCache, Operation),
     {reply, ok, State}.
 
 encode_handoff_item(Key, Operation) ->

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -291,7 +291,7 @@ internal_read(Key, Type, MinSnapshotTime, TxId, OpsCache, SnapshotCache,ShouldGc
 			ignore ->
 			    {ok, Snapshot};
 			_ ->
-			    case NewSS and IsFirst of
+			    case (NewSS and IsFirst) or ShouldGc of
 				%% Only store the snapshot if it would be at the end of the list and has new operations added to the
 				%% previous snapshot
 				true ->

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -346,7 +346,6 @@ snapshot_insert_gc(Key, SnapshotDict, SnapshotCache, OpsCache,ShouldGc)->
             {NewLength,PrunedOps}=prune_ops({Length,OpsDict}, CommitTime),
             ets:insert(SnapshotCache, {Key, PrunedSnapshots}),
 	    true = ets:insert(OpsCache, erlang:make_tuple(?FIRST_OP+?OPS_THRESHOLD,0,[{1,Key},{2,NewLength},{3,OpId}|PrunedOps]));
-	%% true = ets:insert(OpsCache, list_to_tuple([Key,NewLength,OpId|lists:reverse(PrunedOps) ++ lists:seq(NewLength+1,?OPS_THRESHOLD)]));
         false ->
             true = ets:insert(SnapshotCache, {Key, SnapshotDict})
     end.

--- a/src/meta_data_manager.erl
+++ b/src/meta_data_manager.erl
@@ -74,15 +74,15 @@ init([Name]) ->
     {ok, #state{table=Table}}.
 
 handle_cast({update_meta_data, Name, NodeId, Dict}, State) ->
-    true = ets:insert(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), {NodeId, Dict}),
+    ets:insert(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), {NodeId, Dict}),
     {noreply, State};
 
 handle_cast({update_meta_data_new, Name, NodeId}, State) ->
-    true = ets:insert_new(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), {NodeId, undefined}),
+    ets:insert_new(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), {NodeId, undefined}),
     {noreply, State};
 
 handle_cast({remove_node,Name,NodeId}, State) ->
-    true = ets:delete(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), NodeId),
+    ets:delete(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), NodeId),
     {noreply, State};
 
 handle_cast(_Info, State) ->

--- a/src/meta_data_manager.erl
+++ b/src/meta_data_manager.erl
@@ -74,7 +74,7 @@ init([Name]) ->
     {ok, #state{table=Table}}.
 
 handle_cast({update_meta_data, Name, NodeId, Dict}, State) ->
-    ets:insert(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), {NodeId, Dict}),
+    true = ets:insert(meta_data_sender:get_name(Name,?REMOTE_META_TABLE_NAME), {NodeId, Dict}),
     {noreply, State};
 
 handle_cast({update_meta_data_new, Name, NodeId}, State) ->

--- a/src/meta_data_sender.erl
+++ b/src/meta_data_sender.erl
@@ -154,7 +154,7 @@ put_meta_data(Name, Partition, Key, Value, Func) ->
 	    put_meta_dict(Name, Partition, NewDict, undefined)
     end.
 
--spec get_meta_dict(atom(),partition_id()) -> dict().
+-spec get_meta_dict(atom(),partition_id()) -> dict() | undefined.
 get_meta_dict(Name,Partition) ->
     case ets:info(get_name(Name,?META_TABLE_NAME)) of
 	undefined ->
@@ -180,7 +180,7 @@ remove_partition(Name,Partition) ->
 
 %% Add info about a new DC. This info could be
 %% used by other modules to communicate to other DC
--spec get_merged_data(atom()) -> dict().
+-spec get_merged_data(atom()) -> dict() | undefined.
 get_merged_data(Name) ->
     case ets:info(get_name(Name, ?META_TABLE_STABLE_NAME)) of
 	undefined ->
@@ -189,7 +189,7 @@ get_merged_data(Name) ->
 	    case ets:lookup(get_name(Name,?META_TABLE_STABLE_NAME), merged_data) of
 		[] ->
 		    dict:new();
-		[{merged_data,Other}] ->
+		[{merged_data, Other}] ->
 		    Other
 	    end
     end.
@@ -254,7 +254,7 @@ terminate(_Reason, _SN, _SD) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
--spec get_meta_data(atom(),fun((dict()) -> dict()),boolean()) -> {boolean(),dict()} | false.
+-spec get_meta_data(atom(),fun((dict()) -> dict()),boolean()) -> {true,dict()} | false.
 get_meta_data(Name, MergeFunc, CheckNodes) ->
     TablesReady = case ets:info(get_name(Name,?REMOTE_META_TABLE_NAME)) of
 		      undefined ->
@@ -352,14 +352,14 @@ get_node_list() ->
     MyNode = node(),
     lists:delete(MyNode, riak_core_ring:ready_members(Ring)).
 
--spec get_node_and_partition_list() -> {[node()],[partition_id()],boolean()}.
+-spec get_node_and_partition_list() -> {[node()],[partition_id()],true}.
 get_node_and_partition_list() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     MyNode = node(),
     NodeList = lists:delete(MyNode, riak_core_ring:ready_members(Ring)),
     PartitionList = riak_core_ring:my_indices(Ring),
     %% Deciding if the nodes might change by checking the is_resizing function is not
-    %% safe becuase can cause inconsistencies during concurrency, so this should
+    %% safe can cause inconsistencies under concurrency, so this should
     %% be done differently
     %% Resize = riak_core_ring:is_resizing(Ring) or riak_core_ring:is_post_resize(Ring) or riak_core_ring:is_resize_complete(Ring),
     Resize = true,

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -53,8 +53,8 @@ new() ->
 %% in all partitions
 -spec get_stable_snapshot() -> {ok, snapshot_time()}.
 get_stable_snapshot() ->
-    case meta_data_sender:get_merged_data(stable) of
-	undefined ->
+  case meta_data_sender:get_merged_data(stable) of
+	  undefined ->
 	    %% The snapshot isn't realy yet, need to wait for startup
 	    timer:sleep(10),
 	    get_stable_snapshot();
@@ -64,9 +64,9 @@ get_stable_snapshot() ->
 
 -spec get_partition_snapshot(partition_id()) -> snapshot_time().
 get_partition_snapshot(Partition) ->
-    case meta_data_sender:get_meta_dict(stable,Partition) of
-	undefined ->
-	    %% The partition isnt ready yet, wait for startup
+  case meta_data_sender:get_meta_dict(stable,Partition) of
+	  undefined ->
+	    %% The partition isn't ready yet, wait for startup
 	    timer:sleep(10),
 	    get_partition_snapshot(Partition);
 	SS ->


### PR DESCRIPTION
This deals with issue
https://github.com/SyncFree/antidote/issues/83

This addresses two major issues with the materialiser scalability, without changing the functionality.

The first deals with when a new op is added.  Before we had to load the list of ops from the ets table, make a new list with the op appended, then rewrite the entire new list back into ets.  Now it just destructively updates the op in the ets table.

The second deals with workloads that have DC locality, for example where one DC would read and update a key often while another DC would rarely access this key.  In this case at the DC where the object was rarely accessed the list of operations might overflow since garbage collection was only triggered by reads.  Now the GC is forced to trigger before this happens.

There are still many things to be done with the materialiser, but these were two main issues that could be addressed without major refactoring.