### PR TITLE
fix calls to tx execute missing argument

### DIFF
--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -165,7 +165,7 @@ update_objects(Clock, _Properties, Updates, StayAlive) ->
                     {error, Reason}
             end;
         false ->
-            case clocksi_execute_tx(Clock, Operations, StayAlive) of
+            case clocksi_execute_tx(Clock, Operations, update_clock, StayAlive) of
                 {ok, {_TxId, [], CommitTime}} ->
                     {ok, CommitTime};
                 {error, Reason} -> {error, Reason}
@@ -203,7 +203,7 @@ read_objects(Clock, _Properties, Objects, StayAlive) ->
         false ->
             case application:get_env(antidote, txn_prot) of
                 {ok, clocksi} ->
-                    case clocksi_execute_tx(Clock, Args, StayAlive) of
+                    case clocksi_execute_tx(Clock, Args, update_clock, StayAlive) of
                         {ok, {_TxId, Result, CommitTime}} ->
                             {ok, Result, CommitTime};
                         {error, Reason} -> {error, Reason}
@@ -211,7 +211,7 @@ read_objects(Clock, _Properties, Objects, StayAlive) ->
                 {ok, gr} ->
                     case Args of
                         [_Op] -> %% Single object read = read latest value
-                            case clocksi_execute_tx(Clock, Args, StayAlive) of
+                            case clocksi_execute_tx(Clock, Args, update_clock, StayAlive) of
                                 {ok, {_TxId, Result, CommitTime}} ->
                                     {ok, Result, CommitTime};
                                 {error, Reason} -> {error, Reason}


### PR DESCRIPTION
Forgot to add the atom for update_clock in the last pull request
https://github.com/SyncFree/antidote/pull/184