### PR TITLE
Ensure read processes are down when vnodes start

### DIFF
--- a/src/clocksi_readitem_fsm.erl
+++ b/src/clocksi_readitem_fsm.erl
@@ -137,8 +137,19 @@ check_partition_ready(Node,Partition,Num) ->
 start_read_servers_internal(_Node,_Partition,0) ->
     0;
 start_read_servers_internal(Node, Partition, Num) ->
-    {ok,_Id} = clocksi_readitem_sup:start_fsm(Partition,Num),
-    start_read_servers_internal(Node, Partition, Num-1).
+    case clocksi_readitem_sup:start_fsm(Partition,Num) of
+	{ok,_Id} ->
+	    start_read_servers_internal(Node, Partition, Num-1);
+	_ ->
+	    try
+		gen_server:call({global,generate_server_name(Node,Partition,Num)},{go_down})
+	    catch
+		_:_Reason->
+		    ok
+	    end,
+	    start_read_servers_internal(Node, Partition, Num)
+    end.
+	    
 
 stop_read_servers_internal(_Node,_Partition,0) ->
     ok;

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -246,6 +246,12 @@ open_table(Partition) ->
 	_ ->
 	    %% Other vnode hasn't finished closing tables
 	    timer:sleep(100),
+	    try
+		ets:delete(get_cache_name(Partition, prepared))
+	    catch
+		_:_Reason->
+		    ok
+	    end,
 	    open_table(Partition)
     end.
 

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -210,8 +210,13 @@ handle_exit(_Pid, _Reason, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State=#state{ops_cache=OpsCache,snapshot_cache=SnapshotCache}) ->
-    ets:delete(OpsCache),
-    ets:delete(SnapshotCache),
+    try
+	ets:delete(OpsCache),
+	ets:delete(SnapshotCache)
+    catch
+	_:_Reason->
+	    ok
+    end,
     ok.
 
 


### PR DESCRIPTION
Each partition within the ring has a fixed number of processes running (defined in antidote.hrl) that are responsible for handling read requests, allowing reads to happen in parallel.  When a partition is handed off from one physical machine to another, the processes need to be killed on the old physical machine so that the new ones can take new requests.  This change just ensures that these processes are shut down before the news ones are started and forcing it if necessary (hopefully this will help with the ring joining more frequently, but I am not sure since no errors were being thrown before, but in anycase this change should be necessary for stability).

Note that also https://github.com/SyncFree/antidote/pull/187 deals with similar issues, but with different processes.