### PR TITLE
Add network delay across DCs

### DIFF
--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -32,6 +32,8 @@
   observe/1,
   observe_dcs/1,
   observe_dcs_sync/1,
+  add_network_delays/1,
+  add_network_delay/1,
   forget_dc/1,
   forget_dcs/1]).
 
@@ -83,6 +85,15 @@ observe_dcs_sync(Descriptors) ->
     Value = vectorclock:get_clock_of_dc(DCID, SS),
     wait_for_stable_snapshot(DCID, Value)
   end, Descriptors).
+
+-spec add_network_delays([{#descriptor{}, non_neg_integer()}]) -> ok.
+add_network_delays(Descriptors) ->
+    lists:foreach(fun add_network_delay/1, Descriptors).
+
+-spec add_network_delay({#descriptor{}, non_neg_integer()}) -> ok.
+add_network_delay({#descriptor{dcid = DCID}, Delay}) ->
+    lager:info("Adding network delay ~p ms to DC ~p", [Delay, DCID]),
+    dc_utilities:bcast_vnode_sync(inter_dc_sub_vnode_master, {add_delay, DCID, Delay}).
 
 -spec observe_dc_sync(#descriptor{}) -> ok.
 observe_dc_sync(Descriptor) -> observe_dcs_sync([Descriptor]).

--- a/src/inter_dc_sub_vnode.erl
+++ b/src/inter_dc_sub_vnode.erl
@@ -87,7 +87,7 @@ handle_command({txn, Txn = #interdc_txn{dcid = DCID}}, _Sender, State = #state{u
 	    true ->
 		case dict:find(DCID, DcDelays) of
 		    {ok, Time} ->
-			Time;
+			{ok, Time};
 		    error ->
 			false
 		end;
@@ -97,9 +97,8 @@ handle_command({txn, Txn = #interdc_txn{dcid = DCID}}, _Sender, State = #state{u
     case DelayTime of
 	false ->
 	    process_txn(Txn, DCID, State);
-	_ ->
-	    %% lager:info("Adding delay ~p, for ~p", [DelayTime, DCID]),
-	    riak_core_vnode:send_command_after(DelayTime, {txn_delayed}),
+	{ok, Time1} ->
+	    riak_core_vnode:send_command_after(Time1, {txn_delayed}),
 	    {noreply, State#state{queue = queue:in(Txn, Queue)}}
     end;
 


### PR DESCRIPTION
This is just a simple way to add a fixed network delay between DCs that I was using for benchmarking. It works by buffering messages in a queue coming from external DCs for a fixed amount of time.  To enable it you call the "add network delay" function of the interdcmanager module with a DCId and a time in ms.

Of course there are better tools to add network delays, but this works in a pinch (i.e. when you have a paper deadline in a day and you don't have time to configure new tools).

I was just going to delete the branch as I was cleaning, but maybe it is worth keeping around until we setup a better tool.