### PR TITLE
Fix abort

### DIFF
--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -307,7 +307,12 @@ clocksi_execute_tx(Clock, Operations, UpdateClock, KeepAlive) ->
 			       ok = gen_fsm:send_event(TxPid, {start_tx, self(), Clock, Operations, UpdateClock}),
 			       TxPid
 		       end,
-	    gen_fsm:sync_send_event(CoordPid, execute, ?OP_TIMEOUT)
+	    case gen_fsm:sync_send_event(CoordPid, execute, ?OP_TIMEOUT) of
+		{aborted, Info} ->
+		    {error, {aborted, Info}};
+		Other ->
+		    Other
+	    end
     end.
 
 clocksi_execute_tx(Clock, Operations, UpdateClock) ->

--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -79,6 +79,7 @@
     committing_single/3,
     committing/3,
     receive_committed/2,
+    receive_aborted/2,
     abort/1,
     abort/2,
     perform_singleitem_read/2,
@@ -519,24 +520,44 @@ receive_committed(committed, S0 = #tx_coord_state{num_to_ack = NumToAck}) ->
 %% @doc when an error occurs or an updated partition 
 %% does not pass the certification check, the transaction aborts.
 abort(SD0 = #tx_coord_state{transaction = Transaction,
-    updated_partitions = UpdatedPartitions}) ->
-    ok = ?CLOCKSI_VNODE:abort(UpdatedPartitions, Transaction),
-    reply_to_client(SD0#tx_coord_state{state = aborted}).
+			    updated_partitions = UpdatedPartitions}) ->
+    NumToAck = length(UpdatedPartitions),
+    case NumToAck of
+        0 ->
+            reply_to_client(SD0#tx_coord_state{state = aborted});
+        _ ->
+            ok = ?CLOCKSI_VNODE:abort(UpdatedPartitions, Transaction),
+            {next_state, receive_aborted,
+                SD0#tx_coord_state{num_to_ack = NumToAck, state = aborted}}
+    end.
 
-abort(abort, SD0 = #tx_coord_state{transaction = Transaction,
-    updated_partitions = UpdatedPartitions}) ->
-    ok = ?CLOCKSI_VNODE:abort(UpdatedPartitions, Transaction),
-    reply_to_client(SD0#tx_coord_state{state = aborted});
+abort(abort, SD0 = #tx_coord_state{transaction = _Transaction,
+				   updated_partitions = _UpdatedPartitions}) ->
+    abort(SD0);
 
-abort({prepared, _}, SD0 = #tx_coord_state{transaction = Transaction,
-    updated_partitions = UpdatedPartitions}) ->
-    ok = ?CLOCKSI_VNODE:abort(UpdatedPartitions, Transaction),
-    reply_to_client(SD0#tx_coord_state{state = aborted});
+abort({prepared, _}, SD0 = #tx_coord_state{transaction = _Transaction,
+					   updated_partitions = _UpdatedPartitions}) ->
+    abort(SD0);
 
-abort(_, SD0 = #tx_coord_state{transaction = Transaction,
-    updated_partitions = UpdatedPartitions}) ->
-    ok = ?CLOCKSI_VNODE:abort(UpdatedPartitions, Transaction),
-    reply_to_client(SD0#tx_coord_state{state = aborted}).
+abort(_, SD0 = #tx_coord_state{transaction = _Transaction,
+			       updated_partitions = _UpdatedPartitions}) ->
+    abort(SD0).
+
+%% @doc the fsm waits for acks indicating that each partition has successfully
+%%	aborted the tx and finishes operation.
+%%      Should we retry sending the aborted message if we don't receive a
+%%      reply from every partition?
+%%      What delivery guarantees does sending messages provide?
+receive_aborted(ack_abort, S0 = #tx_coord_state{num_to_ack = NumToAck}) ->
+    case NumToAck of
+        1 ->
+            reply_to_client(S0#tx_coord_state{state = aborted});
+        _ ->
+            {next_state, receive_aborted, S0#tx_coord_state{num_to_ack = NumToAck - 1}}
+    end;
+
+receive_aborted(_, S0) ->
+    {next_state, receive_aborted, S0}.
 
 %% @doc when the transaction has committed or aborted,
 %%       a reply is sent to the client that started the transaction.

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -95,8 +95,10 @@ get_stable_snapshot() ->
 get_logid_from_key(_Key) ->
     self().
 
-abort(_UpdatedPartitions, _Transactions) ->
-    ok.
+abort(UpdatedPartitions, _Transactions) ->
+    Self = self(),
+    io:format("sending abort to ~p", [UpdatedPartitions]),
+    lists:foreach(fun({Fsm,Rest}) -> gen_fsm:send_event(Fsm, {ack_abort, Self, Rest}) end, UpdatedPartitions).
 
 single_commit(UpdatedPartitions, _Transaction) ->
     Self = self(),
@@ -162,7 +164,13 @@ execute_op({prepare,From,[{Key,_,_}|_]},State) ->
                 _ -> abort
             end,
     gen_fsm:send_event(From, Result),
+    {next_state, execute_op, State};
+
+execute_op({ack_abort,From,_},State) ->
+    gen_fsm:send_event(From, ack_abort),
     {stop, normal, State}.
+
+
 
 %% =====================================================================
 handle_info(_Info, _StateName, StateData) ->

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -169,8 +169,6 @@ execute_op({ack_abort,From,_},State) ->
     gen_fsm:send_event(From, ack_abort),
     {stop, normal, State}.
 
-
-
 %% =====================================================================
 handle_info(_Info, _StateName, StateData) ->
     {stop,badmsg,StateData}.

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -97,7 +97,6 @@ get_logid_from_key(_Key) ->
 
 abort(UpdatedPartitions, _Transactions) ->
     Self = self(),
-    io:format("sending abort to ~p", [UpdatedPartitions]),
     lists:foreach(fun({Fsm,Rest}) -> gen_fsm:send_event(Fsm, {ack_abort, Self, Rest}) end, UpdatedPartitions).
 
 single_commit(UpdatedPartitions, _Transaction) ->


### PR DESCRIPTION
This fixes two problems that were making the certification check benchmark crash.

The first is when the tx coordinator sends the abort command to the clocksi vnode, the vnode sends back an ack ( https://github.com/SyncFree/antidote/blob/master/src/clocksi_vnode.erl#L366 ), but the coordinator wasn't expecting it, causing it to crash.  Now it waits for the ack to know that the abort was successful.

The second was the execution of a static tx made up of updates was expecting a reply of either ok or error ( https://github.com/SyncFree/antidote/blob/master/src/antidote.erl#L169 ), but the tx coordinator could return ok, error, or abort, now it returns either ok or error, but in the information about the error it says it was an abort.

Actually this brings up another issue, some of the functions in the antidote.erl transaction interface return ok, error, or abort, while others just return ok or error (with abort being a possible reason for the error included with the error).  Shouldn't we choose one of these and stick with it, I like the second option personally?  But maybe this would break the protocol buffer as well?