### PR TITLE
Before starting background processes ensure necessary nodes are started

### DIFF
--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -261,6 +261,8 @@ loop_until_started(Partition, Num) ->
     Ret = clocksi_readitem_fsm:start_read_servers(Partition, Num),
     loop_until_started(Partition, Ret).
 
+handle_command({hello}, _Sender, State) ->
+  {reply, ok, State};
 
 handle_command({check_tables_ready}, _Sender, SD0 = #state{partition = Partition}) ->
     Result = case ets:info(get_cache_name(Partition, prepared)) of

--- a/src/dc_utilities.erl
+++ b/src/dc_utilities.erl
@@ -34,6 +34,7 @@
   ensure_all_vnodes_running_master/1,
   get_partitions_num/0,
   check_staleness/0,
+  check_registered/1,
   now/0,
   now_microsec/0,
   now_millisec/0]).
@@ -155,6 +156,7 @@ check_staleness() ->
 		      ok
 	      end, ok, SS).
 
+-spec check_registered(atom()) -> ok.
 check_registered(Name) ->
     case whereis(Name) of
 	undefined ->

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -95,6 +95,8 @@ connect_nodes([Node|Rest], DCID, LogReaders, Publishers, Desc) ->
 start_bg_processes(Name) ->
     %% Start the meta-data senders
     Nodes = dc_utilities:get_my_dc_nodes(),
+    ok = dc_utilities:ensure_all_vnodes_running_master(inter_dc_log_sender_vnode_master),
+    ok = dc_utilities:ensure_all_vnodes_running_master(clocksi_vnode_master),
     lists:foreach(fun(Node) -> ok = rpc:call(Node, meta_data_sender, start, [Name]) end, Nodes),
     %% Start the timers sending the heartbeats
     lager:info("Starting heartbeat sender timers"),

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -97,7 +97,10 @@ start_bg_processes(Name) ->
     Nodes = dc_utilities:get_my_dc_nodes(),
     ok = dc_utilities:ensure_all_vnodes_running_master(inter_dc_log_sender_vnode_master),
     ok = dc_utilities:ensure_all_vnodes_running_master(clocksi_vnode_master),
-    lists:foreach(fun(Node) -> ok = rpc:call(Node, meta_data_sender, start, [Name]) end, Nodes),
+    lists:foreach(fun(Node) -> 
+			  ok = rpc:call(Node, dc_utilities, check_registered, [meta_data_sender_sup]),
+			  ok = rpc:call(Node, dc_utilities, check_registered, [meta_data_manager_sup]),
+			  ok = rpc:call(Node, meta_data_sender, start, [Name]) end, Nodes),
     %% Start the timers sending the heartbeats
     lager:info("Starting heartbeat sender timers"),
     Responses = dc_utilities:bcast_vnode_sync(inter_dc_log_sender_vnode_master, {start_timer}),


### PR DESCRIPTION
The tests fail sometimes because they try to start the background processes before all vnodes have started running, this just ensures they are all running before.