### PR TITLE
Fix concurrency issue with stable time

### DIFF
--- a/src/inter_dc_log_sender_vnode.erl
+++ b/src/inter_dc_log_sender_vnode.erl
@@ -31,7 +31,8 @@
 
 %% API
 -export([
-  send/2]).
+	 send/2,
+	 send_stable_time/2]).
 
 %% VNode methods
 -export([
@@ -67,6 +68,11 @@
 -spec send(partition_id(), #operation{}) -> ok.
 send(Partition, Operation) -> dc_utilities:call_vnode(Partition, inter_dc_log_sender_vnode_master, {log_event, Operation}).
 
+%% Send the stable time to this vnode, no transaction in the future will commit with a smaller time
+-spec send_stable_time(partition_id(), non_neg_integer()) -> ok.
+send_stable_time(Partition, Time) ->
+    dc_utilities:call_vnode(Partition, inter_dc_log_sender_vnode_master, {stable_time, Time}).
+
 %%%% VNode methods ----------------------------------------------------------+
 
 start_vnode(I) -> riak_core_vnode_master:get_vnode_pid(I, ?MODULE).
@@ -98,13 +104,17 @@ handle_command({log_event, Operation}, _Sender, State) ->
   end,
   {noreply, State2};
 
+handle_command({stable_time, Time}, _Sender, State) ->
+    PingTxn = inter_dc_txn:ping(State#state.partition, State#state.last_log_id, Time),
+    {noreply, set_timer(broadcast(State, PingTxn))};
+
 handle_command({hello}, _Sender, State) ->
   {reply, ok, State};
 
 %% Handle the ping request, managed by the timer (1s by default)
 handle_command(ping, _Sender, State) ->
-    PingTxn = inter_dc_txn:ping(State#state.partition, State#state.last_log_id, get_stable_time(State#state.partition)),
-    {noreply, set_timer(broadcast(State, PingTxn))}.
+    get_stable_time(State#state.partition),
+    {noreply, set_timer(State)}.
 
 handle_coverage(_Req, _KeySpaces, _Sender, State) -> 
     {stop, not_implemented, State}.
@@ -171,8 +181,7 @@ broadcast(State, Txn) ->
   Id = inter_dc_txn:last_log_opid(Txn),
   State#state{last_log_id = Id}.
 
-%% @doc Return smallest snapshot time of active transactions.
+%% @doc Sends an async request to get the smallest snapshot time of active transactions.
 %%      No new updates with smaller timestamp will occur in future.
 get_stable_time(Partition) ->
-    {ok, Time} = logging_vnode:get_stable_time({Partition, node()}),
-    Time.
+    ok = logging_vnode:get_stable_time({Partition, node()}).

--- a/src/inter_dc_log_sender_vnode.erl
+++ b/src/inter_dc_log_sender_vnode.erl
@@ -174,5 +174,5 @@ broadcast(State, Txn) ->
 %% @doc Return smallest snapshot time of active transactions.
 %%      No new updates with smaller timestamp will occur in future.
 get_stable_time(Partition) ->
-    {ok, Time} = clocksi_vnode:get_min_prepared(Partition),
+    {ok, Time} = logging_vnode:get_stable_time({Partition, node()}),
     Time.

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -97,7 +97,7 @@ asyn_read(Preflist, Log) ->
                                    ?LOGGING_MASTER).
 
 %% @doc Sends a `get_stable_time' synchronous command to `Node'
--spec get_stable_time({partition(), node()}) -> {error, term()} | {ok, non_neg_integer()}.
+-spec get_stable_time({partition(), node()}) -> ok.
 get_stable_time(Node) ->
     riak_core_vnode_master:command(Node,
 				   {get_stable_time},

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -31,6 +31,7 @@
 %% API
 -export([start_vnode/1,
          asyn_read/2,
+	 get_stable_time/1,
          read/2,
          asyn_append/3,
          append/3,
@@ -94,6 +95,13 @@ asyn_read(Preflist, Log) ->
                                    {read, Log},
                                    {fsm, undefined, self()},
                                    ?LOGGING_MASTER).
+
+%% @doc Sends a `get_stable_time' synchronous command to `Node'
+-spec get_stable_time({partition(), node()}) -> {error, term()} | {ok, non_neg_integer()}.
+get_stable_time(Node) ->
+    riak_core_vnode_master:sync_command(Node,
+                                        {get_stable_time},
+                                        ?LOGGING_MASTER).
 
 %% @doc Sends a `read' synchronous command to the Logs in `Node'
 -spec read({partition(), node()}, key()) -> {error, term()} | {ok, [term()]}.
@@ -176,6 +184,14 @@ init([Partition]) ->
                         senders_awaiting_ack=dict:new(),
                         last_read=start}}
     end.
+
+%% @doc Read command: Returns the phyiscal time of the 
+%%      clocksi vnode for which no transactions will commit with smaller time
+%%      Output: {ok, Time}
+handle_command({get_stable_time}, _Sender,
+               #state{partition=Partition}=State) ->
+    {ok, Time} = clocksi_vnode:get_min_prepared(Partition),
+    {reply, {ok, Time}, State};
 
 %% @doc Read command: Returns the operations logged for Key
 %%          Input: The id of the log to be read


### PR DESCRIPTION
This fixes an issue where a heartbeat transaction could send a stable time larger than what is safe.

**Problem:**
The clocksi vnode is responsible for ordering transactions within a DC.  During a commit operation, it synchronously sends a log operation to the logging vnode.  Within this operation the logging vnode asynchronously sends a message to the interdc log sender vnode that will then propagate the transaction to other DCs (it is asynchronous as to not block with the requests described below).

To ensure visibility of updates, at a fixed interval of time the log sender vnode sends a heartbeat transaction to other DCs with the physical time for which no transaction new transactions will be committed with smaller time.  To calculate this time it sends a request to the clocksi vnode to check that no transactions are being prepared with a smaller time.  But this heartbeat could have been triggered before some transactions have arrived at the log sender vnode (but after the clocksi vnode sent them), thus sending a heartbeat that would violate causality.

**Fix:**
To fix this, the response from the clocksi vnode with the time is sent through the logging vnode, asynchronously in fifo order to the log sender vnode, thus arriving after any transaction with smaller commit time.