### PR TITLE
bug fixes for materialiser and blocking the logging node

### DIFF
--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -27,7 +27,7 @@
     read_data_item/5,
     async_read_data_item/4,
     get_cache_name/2,
-    get_min_prepared/1,
+    send_min_prepared/1,
     get_active_txns_key/3,
     get_active_txns/2,
     prepare/2,
@@ -150,11 +150,8 @@ get_active_txns_internal(TableName) ->
                 end,
     {ok, ActiveTxs}.
 
-get_min_prepared(Partition) ->
-    riak_core_vnode_master:sync_command({Partition, node()},
-					get_min_prepared,
-					clocksi_vnode_master,
-					infinity).
+send_min_prepared(Partition) ->
+    dc_utilities:call_local_vnode(Partition, clocksi_vnode_master, {send_min_prepared}).
 
 %% @doc Sends a prepare request to a Node involved in a tx identified by TxId
 prepare(ListofNodes, TxId) ->
@@ -281,9 +278,11 @@ handle_command({check_tables_ready}, _Sender, SD0 = #state{partition = Partition
              end,
     {reply, Result, SD0};
 
-handle_command(get_min_prepared, _Sender,
-	       State = #state{prepared_dict = PreparedDict}) ->
-    {reply, get_min_prep(PreparedDict), State};
+handle_command({send_min_prepared}, _Sender,
+	       State = #state{partition = Partition, prepared_dict = PreparedDict}) ->
+    {ok, Time} = get_min_prep(PreparedDict),
+    dc_utilities:call_local_vnode(Partition, logging_vnode_master, {send_min_prepared, Time}),
+    {noreply, State};
 
 handle_command({check_servers_ready}, _Sender, SD0 = #state{partition = Partition, read_servers = Serv}) ->
     loop_until_started(Partition, Serv),

--- a/src/dc_utilities.erl
+++ b/src/dc_utilities.erl
@@ -27,6 +27,7 @@
   bcast_vnode_sync/2,
   partition_to_indexnode/1,
   call_vnode/3,
+  call_local_vnode/3,
   get_all_partitions/0,
   bcast_vnode/2,
   get_my_partitions/0,
@@ -91,6 +92,12 @@ call_vnode_sync(Partition, VMaster, Request) ->
 -spec call_vnode(partition_id(), atom(), any()) -> ok.
 call_vnode(Partition, VMaster, Request) ->
     riak_core_vnode_master:command(partition_to_indexnode(Partition), Request, VMaster).
+
+%% Sends the asynchronous command to a vnode of a specified type and responsible for a specified partition number,
+%% the partition must be on the same node that the command is run on
+-spec call_local_vnode(partition_id(), atom(), any()) -> ok.
+call_local_vnode(Partition, VMaster, Request) ->
+    riak_core_vnode_master:command({Partition, node()}, Request, VMaster).
 
 %% Sends the same (synchronous) command to all vnodes of a given type.
 -spec bcast_vnode_sync(atom(), any()) -> any().

--- a/src/inter_dc_log_sender_vnode.erl
+++ b/src/inter_dc_log_sender_vnode.erl
@@ -71,7 +71,7 @@ send(Partition, Operation) -> dc_utilities:call_vnode(Partition, inter_dc_log_se
 %% Send the stable time to this vnode, no transaction in the future will commit with a smaller time
 -spec send_stable_time(partition_id(), non_neg_integer()) -> ok.
 send_stable_time(Partition, Time) ->
-    dc_utilities:call_vnode(Partition, inter_dc_log_sender_vnode_master, {stable_time, Time}).
+    dc_utilities:call_local_vnode(Partition, inter_dc_log_sender_vnode_master, {stable_time, Time}).
 
 %%%% VNode methods ----------------------------------------------------------+
 
@@ -184,4 +184,4 @@ broadcast(State, Txn) ->
 %% @doc Sends an async request to get the smallest snapshot time of active transactions.
 %%      No new updates with smaller timestamp will occur in future.
 get_stable_time(Partition) ->
-    ok = logging_vnode:get_stable_time({Partition, node()}).
+    ok = clocksi_vnode:send_min_prepared(Partition).

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -188,9 +188,8 @@ init([Partition]) ->
 %% @doc Read command: Returns the phyiscal time of the 
 %%      clocksi vnode for which no transactions will commit with smaller time
 %%      Output: {ok, Time}
-handle_command({get_stable_time}, _Sender,
+handle_command({send_min_prepared, Time}, _Sender,
                #state{partition=Partition}=State) ->
-    {ok, Time} = clocksi_vnode:get_min_prepared(Partition),
     ok = inter_dc_log_sender_vnode:send_stable_time(Partition, Time),
     {noreply, State};
 

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -383,8 +383,10 @@ snapshot_insert_gc(Key, SnapshotDict, SnapshotCache, OpsCache,ShouldGc)->
 				 HalfListLen = ListLen div 2,
 				 case HalfListLen =< ?OPS_THRESHOLD of
 				     true ->
-					 ?OPS_THRESHOLD;
+					 %% Don't shrink list, already minimun size
+					 ListLen;
 				     false ->
+					 %% Only shrink if shrinking would leave some space for new ops
 					 case HalfListLen - ?RESIZE_THRESHOLD > NewLength of
 					     true ->
 						 HalfListLen;


### PR DESCRIPTION
Two bug fixes.

The first is in materializer_vnode.erl, when shrinking the materialiser list size, the wrong value was returned, so the list would actually be smaller than the number of nodes.

The second is in the logging vnode, a previous change I made (https://github.com/SyncFree/antidote/pull/197) caused it to block if the messages were sent in a certain order, this is fixed by not waiting for the response within the same call.