### PR TITLE
Load from log on startup

### DIFF
--- a/riak_test/log_recovery_test.erl
+++ b/riak_test/log_recovery_test.erl
@@ -20,8 +20,6 @@ confirm() ->
 
     lager:info("Nodes: ~p", [Nodes]),
     
-    timer:sleep(15000),
-
     read_pncounter_log_recovery_test(Nodes),
 
     pass.
@@ -58,8 +56,7 @@ read_pncounter_log_recovery_test(Nodes) ->
     rt:wait_until(hd(Nodes), fun wait_init:check_ready/1),
     lager:info("Vnodes are started up"),
     lager:info("Nodes: ~p", [Nodes]),
-    %% Sleep some time to allow recovery from log
-    timer:sleep(15000),
+
     %% Read the value again
     {ok, {_, [ReadResult3], _}} = rpc:call(FirstNode, antidote, clocksi_execute_tx,
 					   [[{read, {Key, Type}}]]),

--- a/riak_test/log_recovery_test.erl
+++ b/riak_test/log_recovery_test.erl
@@ -45,6 +45,8 @@ read_pncounter_log_recovery_test(Nodes) ->
     ?assertEqual(15, ReadResult2),
     lager:info("Killing and restarting the nodes"),
     %% Shut down the nodes
+    %% Sleep a few seconds to let the log be written to disk
+    timer:sleep(5000),
     lists:foreach(fun(ANode) ->
 			  rt:brutal_kill(ANode)
 		  end, Nodes),

--- a/riak_test/log_recovery_test.erl
+++ b/riak_test/log_recovery_test.erl
@@ -1,0 +1,77 @@
+-module(log_recovery_test).
+
+-export([confirm/0]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("antidote.hrl").
+-define(HARNESS, (rt_config:get(rt_harness))).
+
+confirm() ->
+    NumVNodes = rt_config:get(num_vnodes, 8),
+    rt:update_app_config(all, [
+        {riak_core, [{ring_creation_size, NumVNodes}]}
+    ]),
+    [Nodes] = rt:build_clusters([3]),
+    rt:wait_until_ring_converged(Nodes),
+
+    lager:info("Waiting until vnodes are started up"),
+    rt:wait_until(hd(Nodes), fun wait_init:check_ready/1),
+    lager:info("Vnodes are started up"),
+
+    lager:info("Nodes: ~p", [Nodes]),
+    
+    timer:sleep(15000),
+
+    read_pncounter_log_recovery_test(Nodes),
+
+    pass.
+
+%% First we remember the initial time of the counter (with value 0).
+%% After 15 updates, we kill the nodes
+%% We then restart the nodes, aand read the value
+%% being sure that all 15 updates we loaded from the log
+read_pncounter_log_recovery_test(Nodes) ->
+    lager:info("read_snapshot_not_in_ets_test started"),
+    FirstNode = hd(Nodes),
+    Type = crdt_pncounter,
+    Key = log_value_test,
+    {ok, TxId} = rpc:call(FirstNode, antidote, clocksi_istart_tx, []),
+    increment_counter(FirstNode, Key, 15),
+    %% old read value is 0
+    {ok, ReadResult1} = rpc:call(FirstNode,
+        antidote, clocksi_iread, [TxId, Key, Type]),
+    ?assertEqual(0, ReadResult1),
+    %% most recent read value is 15
+    {ok, {_, [ReadResult2], _}} = rpc:call(FirstNode,
+        antidote, clocksi_read, [Key, Type]),
+    ?assertEqual(15, ReadResult2),
+    lager:info("Killing and restarting the nodes"),
+    %% Shut down the nodes
+    lists:foreach(fun(ANode) ->
+			  rt:brutal_kill(ANode)
+		  end, Nodes),
+    lists:foreach(fun(ANode) ->
+			  rt:start_and_wait(ANode)
+		  end, Nodes),
+    rt:wait_until_ring_converged(Nodes),
+    lager:info("Waiting until vnodes are restarted"),
+    rt:wait_until(hd(Nodes), fun wait_init:check_ready/1),
+    lager:info("Vnodes are started up"),
+    lager:info("Nodes: ~p", [Nodes]),
+    %% Sleep some time to allow recovery from log
+    timer:sleep(15000),
+    %% Read the value again
+    {ok, {_, [ReadResult3], _}} = rpc:call(FirstNode, antidote, clocksi_execute_tx,
+					   [[{read, {Key, Type}}]]),
+    ?assertEqual(15, ReadResult3),
+    lager:info("read_pncounter_log_recovery_test").
+
+%% Auxiliary method to increment a counter N times.
+increment_counter(_FirstNode, _Key, 0) ->
+    ok;
+increment_counter(FirstNode, Key, N) ->
+    WriteResult = rpc:call(FirstNode, antidote, clocksi_execute_tx,
+        [[{update, {Key, crdt_pncounter, {increment, a}}}]]),
+    ?assertMatch({ok, _}, WriteResult),
+    increment_counter(FirstNode, Key, N - 1).
+

--- a/src/antidote.app.src
+++ b/src/antidote.app.src
@@ -12,5 +12,5 @@
                   riak_core
                  ]},
   {mod, { antidote_app, []}},
-  {env, [{txn_cert, true}, {txn_prot, clocksi}]}
+  {env, [{txn_cert, true}, {txn_prot, clocksi}, {recover_from_log, true}]}
  ]}.

--- a/src/clocksi_readitem_fsm.erl
+++ b/src/clocksi_readitem_fsm.erl
@@ -112,15 +112,20 @@ check_servers_ready() ->
 check_server_ready([]) ->
     true;
 check_server_ready([{Partition,Node}|Rest]) ->
-    Result = riak_core_vnode_master:sync_command({Partition,Node},
-						 {check_servers_ready},
-						 ?CLOCKSI_MASTER,
-						 infinity),
-    case Result of
-	false ->
-	    false;
-	true ->
-	    check_server_ready(Rest)
+    try
+	Result = riak_core_vnode_master:sync_command({Partition,Node},
+						     {check_servers_ready},
+						     ?CLOCKSI_MASTER,
+						     infinity),
+	case Result of
+	    false ->
+		false;
+	    true ->
+		check_server_ready(Rest)
+	end
+    catch
+	_:_Reason ->
+	    false
     end.
 
 -spec check_partition_ready(node(), partition_id(), non_neg_integer()) -> boolean().

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -27,7 +27,7 @@
     read_data_item/5,
     async_read_data_item/4,
     get_cache_name/2,
-    get_min_prepared/1,
+    send_min_prepared/1,
     get_active_txns_key/3,
     get_active_txns/2,
     prepare/2,
@@ -150,11 +150,8 @@ get_active_txns_internal(TableName) ->
                 end,
     {ok, ActiveTxs}.
 
-get_min_prepared(Partition) ->
-    riak_core_vnode_master:sync_command({Partition, node()},
-					get_min_prepared,
-					clocksi_vnode_master,
-					infinity).
+send_min_prepared(Partition) ->
+    dc_utilities:call_local_vnode(Partition, clocksi_vnode_master, {send_min_prepared}).
 
 %% @doc Sends a prepare request to a Node involved in a tx identified by TxId
 prepare(ListofNodes, TxId) ->
@@ -281,9 +278,11 @@ handle_command({check_tables_ready}, _Sender, SD0 = #state{partition = Partition
              end,
     {reply, Result, SD0};
 
-handle_command(get_min_prepared, _Sender,
-	       State = #state{prepared_dict = PreparedDict}) ->
-    {reply, get_min_prep(PreparedDict), State};
+handle_command({send_min_prepared}, _Sender,
+	       State = #state{partition = Partition, prepared_dict = PreparedDict}) ->
+    {ok, Time} = get_min_prep(PreparedDict),
+    dc_utilities:call_local_vnode(Partition, logging_vnode_master, {send_min_prepared, Time}),
+    {noreply, State};
 
 handle_command({check_servers_ready}, _Sender, SD0 = #state{partition = Partition, read_servers = Serv}) ->
     loop_until_started(Partition, Serv),

--- a/src/clocksi_vnode.erl
+++ b/src/clocksi_vnode.erl
@@ -230,10 +230,16 @@ check_tables_ready() ->
 check_table_ready([]) ->
     true;
 check_table_ready([{Partition, Node} | Rest]) ->
-    Result = riak_core_vnode_master:sync_command({Partition, Node},
-        {check_tables_ready},
-        ?CLOCKSI_MASTER,
-        infinity),
+    Result =
+	try
+	    riak_core_vnode_master:sync_command({Partition, Node},
+						{check_tables_ready},
+						?CLOCKSI_MASTER,
+						infinity)
+	catch
+	    _:_Reason ->
+		false
+	end,
     case Result of
         true ->
             check_table_ready(Rest);

--- a/src/dc_utilities.erl
+++ b/src/dc_utilities.erl
@@ -27,6 +27,7 @@
   bcast_vnode_sync/2,
   partition_to_indexnode/1,
   call_vnode/3,
+  call_local_vnode/3,
   get_all_partitions/0,
   bcast_vnode/2,
   get_my_partitions/0,
@@ -91,6 +92,12 @@ call_vnode_sync(Partition, VMaster, Request) ->
 -spec call_vnode(partition_id(), atom(), any()) -> ok.
 call_vnode(Partition, VMaster, Request) ->
     riak_core_vnode_master:command(partition_to_indexnode(Partition), Request, VMaster).
+
+%% Sends the asynchronous command to a vnode of a specified type and responsible for a specified partition number,
+%% the partition must be on the same node that the command is run on
+-spec call_local_vnode(partition_id(), atom(), any()) -> ok.
+call_local_vnode(Partition, VMaster, Request) ->
+    riak_core_vnode_master:command({Partition, node()}, Request, VMaster).
 
 %% Sends the same (synchronous) command to all vnodes of a given type.
 -spec bcast_vnode_sync(atom(), any()) -> any().

--- a/src/inter_dc_log_sender_vnode.erl
+++ b/src/inter_dc_log_sender_vnode.erl
@@ -71,7 +71,7 @@ send(Partition, Operation) -> dc_utilities:call_vnode(Partition, inter_dc_log_se
 %% Send the stable time to this vnode, no transaction in the future will commit with a smaller time
 -spec send_stable_time(partition_id(), non_neg_integer()) -> ok.
 send_stable_time(Partition, Time) ->
-    dc_utilities:call_vnode(Partition, inter_dc_log_sender_vnode_master, {stable_time, Time}).
+    dc_utilities:call_local_vnode(Partition, inter_dc_log_sender_vnode_master, {stable_time, Time}).
 
 %%%% VNode methods ----------------------------------------------------------+
 
@@ -184,4 +184,4 @@ broadcast(State, Txn) ->
 %% @doc Sends an async request to get the smallest snapshot time of active transactions.
 %%      No new updates with smaller timestamp will occur in future.
 get_stable_time(Partition) ->
-    ok = logging_vnode:get_stable_time({Partition, node()}).
+    ok = clocksi_vnode:send_min_prepared(Partition).

--- a/src/inter_dc_log_sender_vnode.erl
+++ b/src/inter_dc_log_sender_vnode.erl
@@ -183,5 +183,6 @@ broadcast(State, Txn) ->
 
 %% @doc Sends an async request to get the smallest snapshot time of active transactions.
 %%      No new updates with smaller timestamp will occur in future.
+-spec get_stable_time(partition_id()) -> ok.
 get_stable_time(Partition) ->
     ok = clocksi_vnode:send_min_prepared(Partition).

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -97,6 +97,8 @@ start_bg_processes(Name) ->
     Nodes = dc_utilities:get_my_dc_nodes(),
     ok = dc_utilities:ensure_all_vnodes_running_master(inter_dc_log_sender_vnode_master),
     ok = dc_utilities:ensure_all_vnodes_running_master(clocksi_vnode_master),
+    ok = dc_utilities:ensure_all_vnodes_running_master(logging_vnode_master),
+    ok = dc_utilities:ensure_all_vnodes_running_master(materializer_vnode_master),
     lists:foreach(fun(Node) -> 
 			  ok = rpc:call(Node, dc_utilities, check_registered, [meta_data_sender_sup]),
 			  ok = rpc:call(Node, dc_utilities, check_registered, [meta_data_manager_sup]),

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -99,6 +99,7 @@ start_bg_processes(Name) ->
     ok = dc_utilities:ensure_all_vnodes_running_master(clocksi_vnode_master),
     ok = dc_utilities:ensure_all_vnodes_running_master(logging_vnode_master),
     ok = dc_utilities:ensure_all_vnodes_running_master(materializer_vnode_master),
+    wait_init:wait_ready(hd(Nodes)),
     lists:foreach(fun(Node) -> 
 			  ok = rpc:call(Node, dc_utilities, check_registered, [meta_data_sender_sup]),
 			  ok = rpc:call(Node, dc_utilities, check_registered, [meta_data_manager_sup]),

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -444,7 +444,10 @@ handle_handoff_command(?FOLD_REQ{foldfun=FoldFun, acc0=Acc0}, _Sender,
                        #state{logs_map=Map}=State) ->
     F = fun({Key, Operation}, Acc) -> FoldFun(Key, Operation, Acc) end,
     Acc = join_logs(dict:to_list(Map), F, Acc0),
-    {reply, Acc, State}.
+    {reply, Acc, State};
+
+handle_handoff_command({get_all, _logId}, _Sender, State) ->
+    {reply, {error, not_ready}, State}.
 
 handoff_starting(_TargetNode, State) ->
     {true, State}.

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -188,9 +188,8 @@ init([Partition]) ->
 %% @doc Read command: Returns the phyiscal time of the 
 %%      clocksi vnode for which no transactions will commit with smaller time
 %%      Output: {ok, Time}
-handle_command({get_stable_time}, _Sender,
+handle_command({send_min_prepared, Time}, _Sender,
                #state{partition=Partition}=State) ->
-    {ok, Time} = clocksi_vnode:get_min_prepared(Partition),
     ok = inter_dc_log_sender_vnode:send_stable_time(Partition, Time),
     {noreply, State};
 

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -383,8 +383,10 @@ snapshot_insert_gc(Key, SnapshotDict, SnapshotCache, OpsCache,ShouldGc)->
 				 HalfListLen = ListLen div 2,
 				 case HalfListLen =< ?OPS_THRESHOLD of
 				     true ->
-					 ?OPS_THRESHOLD;
+					 %% Don't shrink list, already minimun size
+					 ListLen;
 				     false ->
+					 %% Only shrink if shrinking would leave some space for new ops
 					 case HalfListLen - ?RESIZE_THRESHOLD > NewLength of
 					     true ->
 						 HalfListLen;

--- a/src/wait_init.erl
+++ b/src/wait_init.erl
@@ -20,6 +20,7 @@
 -module(wait_init).
 
 -export([wait_ready_nodes/1,
+	 wait_ready/1,
 	 check_ready/1
         ]).
 
@@ -37,6 +38,17 @@ wait_ready_nodes([Node|Rest]) ->
 	    wait_ready_nodes(Rest);
 	false ->
 	    false
+    end.
+
+%% @doc This calls the check_ready function repatabliy
+%% until it returns true
+wait_ready(Node) ->
+    case check_ready(Node) of
+	true ->
+	    true;
+	false ->
+	    timer:sleep(1000),
+	    check_ready(Node)
     end.
 
 %% @doc This function provides the same functionality as wait_ready_nodes


### PR DESCRIPTION
On startup, operations will be loaded from the log into the memory if this is enabled on the line
https://github.com/SyncFree/antidote/blob/load-from-log/src/antidote.app.src#L15
This resolves part of the issue described here
https://github.com/SyncFree/antidote/issues/193

It takes some time to load from the log, so be sure to call the wait_init:check_ready function on a node in the DC to be sure things have been loaded, here is an example of where this is used:
https://github.com/SyncFree/antidote/blob/load-from-log/riak_test/log_recovery_test.erl#L56
(The function inter_dc_manager:start_bg_processes also does this)
https://github.com/SyncFree/antidote/blob/load-from-log/riak_test/common.erl#L67

Please test with your applications to see that this is working correctly.

A new test is added.

This should be pulled after
https://github.com/SyncFree/antidote/pull/199