### PR TITLE
fix interdc blocking

### DIFF
--- a/src/inter_dc_dep_vnode.erl
+++ b/src/inter_dc_dep_vnode.erl
@@ -116,7 +116,10 @@ try_store(State, Txn=#interdc_txn{dcid = DCID, partition = Partition, timestamp 
   case vectorclock:ge(CurrentClock, Dependencies) of
 
     %% If not, the transaction will not be stored right now.
-    false -> {State, false};
+    %% Still need to update the timestamp for that DC, up to 1 less than the
+    %% value of the commit time, because updates from other DCs might depend
+    %% on a time up to this
+    false -> {update_clock(State, DCID, Timestamp-1), false};
 
     %% If so, store the transaction
     true ->

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -159,6 +159,8 @@ forget_dc(#descriptor{dcid = DCID}) ->
 -spec forget_dcs([#descriptor{}]) -> ok.
 forget_dcs(Descriptors) -> lists:foreach(fun forget_dc/1, Descriptors).
 
+%% Tell nodes within the DC to drop heartbeat ping messages from other
+%% DCs, used for debugging
 -spec drop_ping(boolean()) -> ok.
 drop_ping(DropPing) ->
     Responses = dc_utilities:bcast_vnode_sync(inter_dc_dep_vnode_master, {drop_ping, DropPing}),

--- a/src/inter_dc_manager.erl
+++ b/src/inter_dc_manager.erl
@@ -34,7 +34,8 @@
   observe_dcs/1,
   observe_dcs_sync/1,
   forget_dc/1,
-  forget_dcs/1]).
+  forget_dcs/1,
+  drop_ping/1]).
 
 -spec get_descriptor() -> {ok, #descriptor{}}.
 get_descriptor() ->
@@ -157,6 +158,14 @@ forget_dc(#descriptor{dcid = DCID}) ->
 
 -spec forget_dcs([#descriptor{}]) -> ok.
 forget_dcs(Descriptors) -> lists:foreach(fun forget_dc/1, Descriptors).
+
+-spec drop_ping(boolean()) -> ok.
+drop_ping(DropPing) ->
+    Responses = dc_utilities:bcast_vnode_sync(inter_dc_dep_vnode_master, {drop_ping, DropPing}),
+    %% Be sure they all returned ok, crash otherwise
+    ok = lists:foreach(fun({_, ok}) ->
+			       ok
+		       end, Responses).    
 
 %%%%%%%%%%%%%
 %% Utils


### PR DESCRIPTION
This small change fixes a bug that could cause the interDC layer to block, resulting in updates from other DCs to buffer forever.  It only happens with 3 or more DCs, and usually needs a high update rate at multiple DCs.  The problem happens when two updates from two different DCs arrive at a third DC and each of them depend on a timestamp for the other DC that is more recent than the latest timestamp received at the third DC.  (Note that the reason why they are not processed until their dependencies are satisfied is so that updates are sent to the materialiser in causal order)

To fix this, when an update cannot be applied due to its dependencies not being met, the "received time" for the DC that sent this update is increased to 1 minus the commit time of this update.  This is safe to do because updates from an external DC are processed in the order of their commit time.

Note that these are per "shard" dependencies, so the visibility of these updates is still governed by the global stable time.