### PR TITLE
added handling for reading from log in physics

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "git://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
     {antidote_crdt, ".*", {git, "git://github.com/syncfree/antidote_crdt", {tag, "0.0.4"}}},
-    {antidote_utils, {git, "git://github.com/syncfree/antidote_utils", {tag, "0.0.1"}}},
+    {antidote_utils, {git, "git://github.com/syncfree/antidote_utils", {branch, "vectorclock-renaming"}}},
     {rand_compat, {git, "https://github.com/lasp-lang/rand_compat.git", {ref, "b2cf40b6ef14a5d7fbc67276e9164de7cc7c7906"}}}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "git://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
     {antidote_crdt, ".*", {git, "git://github.com/syncfree/antidote_crdt", {tag, "0.0.4"}}},
-    {antidote_utils, {git, "git://github.com/syncfree/antidote_utils", {branch, "vectorclock-renaming"}}},
+    {antidote_utils, {git, "git://github.com/syncfree/antidote_utils", {tag, "0.2.0"}}},
     {rand_compat, {git, "https://github.com/lasp-lang/rand_compat.git", {ref, "b2cf40b6ef14a5d7fbc67276e9164de7cc7c7906"}}}
 ]}.
 

--- a/src/logging_vnode.erl
+++ b/src/logging_vnode.erl
@@ -714,7 +714,7 @@ handle_commit(TxId, OpPayload, T, Key, MinSnapshotTime, Ops, CommittedOpsDict) -
 	    NewCommittedOpsDict = 
 		lists:foldl(fun(#update_log_payload{key = KeyInternal, type = Type, op = Op}, Acc) ->
 				    case ((MinSnapshotTime == undefined) orelse
-									   (not vectorclock:gt(SnapshotTime, MinSnapshotTime))) of
+									   (not vectorclock:all_dots_greater(SnapshotTime, MinSnapshotTime))) of
 					true ->
 					    CommittedDownstreamOp =
 						#clocksi_payload{


### PR DESCRIPTION
Updates antidote to use the new names of vector clock functions.

Do not merge until  the following antidote_utils PR is merged.
https://github.com/SyncFree/antidote_utils/pull/6

ToDo: generate tag for the antidote_utils version after merge, and assign to rebar.config.

https://github.com/SyncFree/antidote/compare/vectorclock-upgrade?expand=1#diff-31d7a50c99c265ca2793c20961b60979R13
