### PR TITLE
Launch multiple nodes.

### DIFF
--- a/bin/env
+++ b/bin/env
@@ -20,6 +20,16 @@ if [ -z "$LOGREADER_PORT" ]; then
   export LOGREADER_PORT=8085
 fi
 
+# Ring State directory.
+if [ -z "$RING_STATE_DIR" ]; then
+  export RING_STATE_DIR="data/ring"
+fi
+
+# Platform data directory.
+if [ -z "$PLATFORM_DATA_DIR" ]; then
+  export PLATFORM_DATA_DIR="data"
+fi
+
 # If we're running in Mesos...
 if [ ! -z "$MESOS_TASK_ID" ]; then
   # Choose publicly routable IP.

--- a/bin/launch-nodes.sh
+++ b/bin/launch-nodes.sh
@@ -4,6 +4,6 @@ export RELX_REPLACE_OS_VARS=true
 
 for i in `seq 1 10`;
 do
-  HANDOFF_PORT=8${i}99 PB_PORT=8${i}87 PUBSUB_PORT=8${i}86 LOGREADER_PORT=8${i}85 NODE_NAME=antidote-${i} _build/default/rel/antidote/bin/antidote foreground &
+  PLATFORM_DATA_DIR="data/${i}" RING_STATE_DIR="data/ring/${i}" HANDOFF_PORT=8${i}99 PB_PORT=8${i}87 PUBSUB_PORT=8${i}86 LOGREADER_PORT=8${i}85 NODE_NAME=antidote-${i} _build/default/rel/antidote/bin/antidote foreground &
   sleep 1
 done

--- a/bin/launch-nodes.sh
+++ b/bin/launch-nodes.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export RELX_REPLACE_OS_VARS=true
+
+for i in `seq 1 10`;
+do
+  HANDOFF_PORT=8${i}99 PB_PORT=8${i}87 PUBSUB_PORT=8${i}86 LOGREADER_PORT=8${i}85 NODE_NAME=antidote-${i} _build/default/rel/antidote/bin/antidote foreground &
+  sleep 1
+done

--- a/config/sys.config
+++ b/config/sys.config
@@ -2,8 +2,8 @@
  %% Riak Core config
  {riak_core, [
               %% Default location of ringstate
-              {ring_state_dir, "data/ring"},
-              {platform_data_dir, "data"},
+              {ring_state_dir, "${RING_STATE_DIR}"},
+              {platform_data_dir, "${PLATFORM_DATA_DIR}"},
 
               %% riak_handoff_port is the TCP port that Riak uses for
               %% intra-cluster data handoff.

--- a/config/vm.args
+++ b/config/vm.args
@@ -39,5 +39,3 @@
 
 ## Riak Core configuration values coming from the command line.
 -riak_core handoff_port ${HANDOFF_PORT}
--riak_core ring_state_dir ${RING_STATE_DIR}
--riak_core platform_data_dir ${PLATFORM_DATA_DIR}

--- a/config/vm.args
+++ b/config/vm.args
@@ -39,3 +39,5 @@
 
 ## Riak Core configuration values coming from the command line.
 -riak_core handoff_port ${HANDOFF_PORT}
+-riak_core ring_state_dir ${RING_STATE_DIR}
+-riak_core platform_data_dir ${PLATFORM_DATA_DIR}


### PR DESCRIPTION
It's no longer necessary to build multiple releases to run multiple
instances of the system, as you can use the dynamic configuration as
supported by rebar3.