### PR TITLE
Disable time-warp mode for releases

### DIFF
--- a/config/vm.args
+++ b/config/vm.args
@@ -24,8 +24,8 @@
 ## Increase distribution port buffer size.
 +zdbbl 32768
 
-## Enable multi_time_warp.
-+C multi_time_warp
+## Disable time_warp, because Antidote is not time-warp safe at the moment (see https://github.com/SyncFree/antidote/issues/226)
++C no_time_warp
 
 ## The following section is required beacuse variable replacement can
 ## only occur with string, not integers.


### PR DESCRIPTION
Antidote needs monotonic time at the moment, so time-warp mode should be disabled (see https://github.com/SyncFree/antidote/issues/226)