### PR TITLE
Makefile target for rebar3 shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ docs/.idea/
 log/
 data/
 compile_commands.json
+data.*/
+log.*/
+erl_crash.dump
+rebar3.crashdump
+test/.rebar3/erlcinfo

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,14 @@ cleantests:
 	rm -rf logs/
 
 shell:
-	$(REBAR) shell
+	$(REBAR) shell --name='antidote@127.0.0.1' --setcookie antidote --config config/sys-debug.config
+
+# same as shell, but automatically reloads code when changed
+# to install add `{plugins, [rebar3_auto]}.` to ~/.config/rebar3/rebar.config
+# the tool requires inotifywait (sudo apt install inotify-tools)
+# see https://github.com/vans163/rebar3_auto or http://blog.erlware.org/rebar3-auto-comile-and-load-plugin/ 
+auto:
+	$(REBAR) auto --name='antidote@127.0.0.1' --setcookie antidote --config config/sys-debug.config
 
 rel:
 	$(REBAR) release

--- a/config/sys-debug.config
+++ b/config/sys-debug.config
@@ -1,0 +1,37 @@
+[
+ %% Riak Core config
+ {riak_core, [
+              %% Default location of ringstate
+              {ring_state_dir, "data.antidote@127.0.0.1/ring"},
+              {platform_data_dir, "data.antidote@127.0.0.1"},
+              {schema_dirs, [
+                "_build/default/lib/cuttlefish/priv/",
+                "_build/default/lib/riak_core/priv/",
+                "_build/default/lib/riak_sysmon/priv/",
+                "_build/default/lib/eleveldb/priv/"
+              ]},
+
+              %% riak_handoff_port is the TCP port that Riak uses for
+              %% intra-cluster data handoff.
+              {handoff_port, 8099}
+             ]},
+
+ %% SASL config
+ {sasl, [
+         {sasl_error_logger, {file, "log.antidote@127.0.0.1/sasl-error.log"}},
+         {errlog_type, error},
+         {error_logger_mf_dir, "log.antidote@127.0.0.1/sasl"},      % Log directory
+         {error_logger_mf_maxbytes, 10485760},   % 10 MB max file size
+         {error_logger_mf_maxfiles, 5}           % 5 files max
+         ]},
+
+ {riak_api, [
+        {pb_ip, "127.0.0.1"},
+        {pb_port, 8087}
+        ]},
+
+  {antidote, [
+    {pubsub_port, 8086},
+    {logreader_port, 8085}
+  ]}
+].


### PR DESCRIPTION
The `rebar3 shell` was no longer working.

I created a special config file `sys-debug.config` for use with the shell. It is similar to the `sys.config` used for releases, but does not use environment variables. I also had to add the `schema_dirs` configuration for riak_core to make it work.

Besides the `make shell` target, I also added a `make auto` target for a shell which automatically compiles and reloads the code when it is changed on disk (see https://github.com/vans163/rebar3_auto).