### PR TITLE
Add readset to generate downstream operations at the coordinator

### DIFF
--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -213,6 +213,7 @@
           state :: active | prepared | committing | committed | undefined
                  | aborted | committed_read_only,
           operations :: undefined | list(),
+		  internal_read_set :: orddict(),
           read_set :: list(),
           is_static :: boolean(),
           full_commit :: boolean(),


### PR DESCRIPTION
This PR addresses issue #249.
Creates an internal read set at the interactive tx coordinator in order to avoid sending read messages to the clocksi_vnode to generate downstream, when the object has already been read by the transaction (which is expected to be frequent in practice).