### PR TITLE
Fix read order for batch-read

### DIFF
--- a/src/clocksi_static_tx_coord_fsm.erl
+++ b/src/clocksi_static_tx_coord_fsm.erl
@@ -198,11 +198,11 @@ receive_prepared({ok, {Key, Type, Snapshot}},
                     case NumToCommit of
                         0 ->
                             clocksi_interactive_tx_coord_fsm:reply_to_client(S0#tx_coord_state{state=committed_read_only, 
-                            read_set=lists:reverse(ReadSet1)});
+                            read_set=ReadSet1});
                         _ ->
                             ok = ?CLOCKSI_VNODE:commit(UpdatedPartitions, Transaction, CommitTime),
                             {next_state, receive_committed,
-                               S0#tx_coord_state{num_to_ack=NumToCommit, read_set=lists:reverse(ReadSet1), state=committing}}
+                               S0#tx_coord_state{num_to_ack=NumToCommit, read_set=ReadSet1, state=committing}}
                     end;
                 _ ->
                     {next_state, receive_prepared, S0#tx_coord_state{num_to_read= NumToRead-1,


### PR DESCRIPTION
When reading multiple objects the values are currently returned in reverse order.

I removed two calls to `lists:reverse` to fix this. I am not sure if this is the right place to change it.
Maybe @marsleezm can have a look at it (the code was commited in https://github.com/SyncFree/antidote/commit/6e23cb56cf8be9180858135e54193ebf4ed5bcfc).

@aletomsic I've seen that you changed something with the read-set in #250 
If you already fixed this, you can just copy my testcase to your branch and close this pull-request.