### PR TITLE
(WIP) Improve error handling for keepalive connections

### DIFF
--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -193,6 +193,8 @@
 %% @doc Data Type: state
 %% where:
 %%    from: the pid of the calling process.
+%%    keepalive_from: the pid of the process, which started the transaction, 
+                      used for sending errors on crashes
 %%    txid: transaction id handled by this fsm, as defined in src/antidote.hrl.
 %%    updated_partitions: the partitions where update operations take place.
 %%    num_to_ack: when sending prepare_commit,
@@ -204,6 +206,7 @@
 
 -record(tx_coord_state, {
           from :: undefined | {pid(), term()},
+          keepalive_from :: pid() | undefined,
           transaction :: undefined | tx(),
           updated_partitions :: list(),
           client_ops :: list(), % list of upstream updates, used for post commit hooks

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -194,7 +194,7 @@
 %% where:
 %%    from: the pid of the calling process.
 %%    keepalive_from: the pid of the process, which started the transaction, 
-                      used for sending errors on crashes
+%%                    used for sending errors on crashes
 %%    txid: transaction id handled by this fsm, as defined in src/antidote.hrl.
 %%    updated_partitions: the partitions where update operations take place.
 %%    num_to_ack: when sending prepare_commit,

--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -400,9 +400,14 @@ clocksi_istart_tx(Clock, KeepAlive) ->
     receive
         {ok, TxId} ->
             {ok, TxId};
+        {error, crashed} when KeepAlive ->
+          % try again without KeepAlive
+          clocksi_istart_tx(Clock, false);
         Other ->
             {error, Other}
     end.
+
+
 
 clocksi_istart_tx(Clock) ->
     clocksi_istart_tx(Clock, false).

--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -668,7 +668,7 @@ code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
 terminate(normal, _SN, _SD) ->
   ok;
 % if there is a crash and this is a keepalive fsm, send the error to the owning process
-terminate(Reason, SN, #tx_coord_state{keepalive_from = Pid}=SD) ->
+terminate(_Reason, _SN, #tx_coord_state{keepalive_from = Pid}) ->
     case Pid of
     undefined ->
         ok;

--- a/test/pb_client_SUITE.erl
+++ b/test/pb_client_SUITE.erl
@@ -42,7 +42,7 @@
   update_set_read_test/1,
   static_transaction_test/1,
   crdt_integer_test/1,
-  update_reg_test/1, crdt_mvreg_test/1, crdt_set_rw_test/1, crdt_map_aw_test/1, crdt_gmap_test/1]).
+  update_reg_test/1, crdt_mvreg_test/1, crdt_set_rw_test/1, crdt_map_aw_test/1, crdt_gmap_test/1, client_fail_test/1, client_fail_test2/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -71,6 +71,8 @@ all() -> [start_stop_test,
         simple_transaction_test,
         read_write_test,
         get_empty_crdt_test,
+        client_fail_test,
+        client_fail_test2,
         pb_test_counter_read_write,
         pb_test_set_read_write,
         pb_empty_txn_clock_test,
@@ -119,6 +121,39 @@ get_empty_crdt_test(_Config) ->
     {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
     {ok, [Val]} = antidotec_pb:read_objects(Pid, [Bound_object], TxId),
     {ok, _} = antidotec_pb:commit_transaction(Pid, TxId),
+    _Disconnected = antidotec_pb_socket:stop(Pid),
+    ?assertMatch(true, antidotec_counter:is_type(Val)).
+
+
+client_fail_test(_Config) ->
+    {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
+    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter, <<"bucket">>},
+    {ok, TxIdFail} = antidotec_pb:start_transaction(Pid, ignore, {}),
+    % Client fails and starts next transaction:
+    {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
+    {ok, [Val]} = antidotec_pb:read_objects(Pid, [Bound_object], TxId),
+    {ok, _} = antidotec_pb:commit_transaction(Pid, TxId),
+    _Disconnected = antidotec_pb_socket:stop(Pid),
+    ?assertMatch(true, antidotec_counter:is_type(Val)).
+
+
+client_fail_test2(_Config) ->
+    {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
+    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter, <<"bucket">>},
+    {ok, TxIdFail} = antidotec_pb:start_transaction(Pid, ignore, {}),
+    % Client fails and starts next transaction:
+    {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
+    {ok, [Val]} = antidotec_pb:read_objects(Pid, [Bound_object], TxId),
+    {ok, _} = antidotec_pb:commit_transaction(Pid, TxId),
+
+    {ok, TxId2} = antidotec_pb:start_transaction(Pid, ignore, {}),
+    {ok, [Val]} = antidotec_pb:read_objects(Pid, [Bound_object], TxId2),
+    {ok, _} = antidotec_pb:commit_transaction(Pid, TxId2),
+
+    {ok, TxId3} = antidotec_pb:start_transaction(Pid, ignore, {}),
+    {ok, [Val]} = antidotec_pb:read_objects(Pid, [Bound_object], TxId3),
+    {ok, _} = antidotec_pb:commit_transaction(Pid, TxId3),
+
     _Disconnected = antidotec_pb_socket:stop(Pid),
     ?assertMatch(true, antidotec_counter:is_type(Val)).
 


### PR DESCRIPTION
@deepthidevaki did this together with me

Problem: When the client crashes during a transaction, the fsm is stuck in an already started transaction.
So when the client tries to start a new transaction, the fsm crashes and the connection is no longer  usable if it is KeepAlive=true.

Fix: When the clocksi_interactivetx_coord_fsm crashes, it will send an error to the process that started the transaction. If the connection is using KeepAlive it will try to restart the transaction with a new fsm.