### PR TITLE
Disable keepalive

### DIFF
--- a/src/antidote_pb_txn.erl
+++ b/src/antidote_pb_txn.erl
@@ -74,7 +74,7 @@ process(#apbstarttransaction{timestamp=BClock, properties = BProperties},
                     _ -> binary_to_term(BClock)
             end,
     Properties = antidote_pb_codec:decode(txn_properties, BProperties),
-    Response = antidote:start_transaction(Clock, Properties, true),
+    Response = antidote:start_transaction(Clock, Properties, false),
     case Response of
         {ok, TxId} ->
             {reply, antidote_pb_codec:encode(start_transaction_response,
@@ -161,7 +161,7 @@ process(#apbstaticupdateobjects{
     Updates = lists:map(fun(O) ->
                                 antidote_pb_codec:decode(update_object, O) end,
                         BUpdates),
-    Response = antidote:update_objects(Clock, Properties, Updates, true),
+    Response = antidote:update_objects(Clock, Properties, Updates, false),
     case Response of
         {error, Reason} ->
             {reply, antidote_pb_codec:encode(commit_response,
@@ -182,7 +182,7 @@ process(#apbstaticreadobjects{
     Objects = lists:map(fun(O) ->
                                 antidote_pb_codec:decode(bound_object, O) end,
                         BoundObjects),
-    Response = antidote:read_objects(Clock, Properties, Objects, true),
+    Response = antidote:read_objects(Clock, Properties, Objects, false),
     case Response of
         {error, Reason} ->
             {reply, antidote_pb_codec:encode(commit_response,


### PR DESCRIPTION
Keepalive=true keeps transaction coord alive after a transaction commits and will be used for following transactions started by the same process. It was added as an optimization that avoids spawning new fsms for each transaction. But, when a client starts a new transaction before committing previous transaction, keepalive coordinator crashes. As a temporary fix, this pull requests:

- disables keepalive for protocol buffer clients.
- added a test that will fail when keepalive is set to true.

@aletomsic We have to decide if keepalive coordinators are needed. If it has some performance benefit, we can try to fix the bugs. Otherwise it should be removed.

PS:- We tried to fix it in this closed pull request #258. The fix caused other tests to fail.
