### PR TITLE
update riak_core from hex; removes erocksdb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {deps, [
     {lager, "3.2.1"},
     %%{riak_core, {git, "https://github.com/project-fifo/riak_core", {branch, "fifo-0.7.1"}}},
-    {riak_core, "2.2.6", {pkg, riak_core_ng}},
+    {riak_core, "2.2.8", {pkg, riak_core_ng}},
     {riak_dt,  {git, "git://github.com/aletomsic/riak_dt", {tag, "type_check_antidote"}}},
     %% TODO: riak_pb branch "antidote_crdt"
     {riak_pb, {git, "git://github.com/syncfree/riak_pb", {tag, "v0.2.0"}}},


### PR DESCRIPTION
The newest version of riak_core_ng from hex does no longer have the erocksdb as a dependency. This should considerably speed-up the build processes.

The unit-tests run through and the systests on my local machine as well.