### PR TITLE
added Dockerfile and files required to build the Docker image

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,0 +1,45 @@
+FROM erlang:19
+
+ENV HANDOFF_PORT "8099"
+ENV PB_PORT "8087"
+ENV PB_IP "0.0.0.0"
+ENV PBSUB_PORT "8086"
+ENV LOGREADER_PORT "8085"
+ENV RING_STATE_DIR "data/ring"
+ENV PLATFORM_DATA_DIR "data"
+ENV NODE_NAME "antidote@127.0.0.1"
+ENV SHORT_NAME "false"
+ENV ANTIDOTE_REPO "https://github.com/SyncFree/antidote.git"
+ENV ANTIDOTE_BRANCH "master"
+
+RUN set -xe \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends git openssl ca-certificates \
+  && cd /usr/src \
+  && git clone $ANTIDOTE_REPO \
+  && cd antidote \
+  && git checkout $ANTIDOTE_BRANCH \
+  && make rel \
+  && cp -R _build/default/rel/antidote /opt/ \
+  && sed -e '$i,{kernel, [{inet_dist_listen_min, 9100}, {inet_dist_listen_max, 9100}]}' /usr/src/antidote/_build/default/rel/antidote/releases/0.0.1/sys.config > /opt/antidote/releases/0.0.1/sys.config \
+  && rm -rf /usr/src/antidote /var/lib/apt/lists/*
+
+ADD ./start_and_attach.sh /opt/antidote/
+ADD ./entrypoint.sh /
+
+RUN chmod a+x /opt/antidote/start_and_attach.sh \
+  && chmod a+x /entrypoint.sh
+
+# Distributed Erlang Port Mapper
+EXPOSE 4368
+# Ports for Antidote
+EXPOSE 8085 8086 8087 8099
+
+# Antidote RPC
+EXPOSE 9100
+
+VOLUME /opt/antidote/data
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/opt/antidote/start_and_attach.sh"]

--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+if [ ! -f /opt/antidote/releases/0.0.1/setup_ok ]; then
+  cd /opt/antidote/releases/0.0.1/
+  cp vm.args vm.args_backup
+  if [ "$SHORT_NAME" = "true" ]; then
+    sed "s/-name /-sname /" vm.args_backup > vm.args
+  fi
+  touch setup_ok
+fi
+
+exec "$@"

--- a/Dockerfiles/start_and_attach.sh
+++ b/Dockerfiles/start_and_attach.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+NPROC=$(nproc)
+
+if [ "$NPROC" -ge 2 ]; then
+  trap "echo 'Shutting down' && /opt/antidote/bin/env stop" TERM
+  /opt/antidote/bin/env start && sleep 10 && tail -f /opt/antidote/log/console.log & wait ${!}
+else
+  echo "You need at least 2 cpu cores in your Docker (virtual) machine to run this image!"
+  echo "You have ${NPROC} processors"
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a Dockerfile and the required files to build a non-interactive container for Antidote. The container can be started in daemon-mode to run in the background and allows to configure several environment variables. Fixes are included to be able to build clusters of several Antidote nodes (e.g. binding the Erlang RPC server to a fixed port).

Adding these files allows to add an automated build to Docker-Hub in order to always have an up-to-date Docker image of the master branch (see https://hub.docker.com/r/mweber/antidote/)