### PR TITLE
Remove antidote utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - make test
   - make reltest
   - make systests
+  - make dialyzer
 notifications:
   email: christopher.meiklejohn@gmail.com
 sudo: required

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -160,7 +160,7 @@
 -type dc_and_commit_time() ::  {dcid(), clock_time()}.
 
 -record(tx_id, {local_start_time :: clock_time(),
-  server_pid :: atom()}).
+  server_pid :: atom() | pid()}).
 -record(clocksi_payload, {key :: key(),
   type :: type(),
   op_param :: op(),

--- a/include/antidote.hrl
+++ b/include/antidote.hrl
@@ -1,4 +1,3 @@
--include_lib("antidote_utils/include/antidote_utils.hrl").
 
 -define(BUCKET, <<"antidote">>).
 -define(MASTER, antidote_vnode_master).
@@ -150,6 +149,29 @@
 				value :: snapshot()}).
 
 %%---------------------------------------------------------------------
+-type downstream_record() :: term().
+-type actor() :: term().
+-type key() :: term().
+-type op()  :: {update | merge, downstream_record()}.
+-type type() :: atom().
+-type dcid() :: 'undefined' | {atom(),tuple()}. %% TODO, is this the only structure that is returned by riak_core_ring:cluster_name(Ring)?
+-type snapshot_time() ::  vectorclock:vectorclock().
+-type clock_time() :: non_neg_integer().
+-type dc_and_commit_time() ::  {dcid(), clock_time()}.
+
+-record(tx_id, {local_start_time :: clock_time(),
+  server_pid :: atom()}).
+-record(clocksi_payload, {key :: key(),
+  type :: type(),
+  op_param :: op(),
+  snapshot_time :: snapshot_time(),
+  commit_time :: dc_and_commit_time(),
+  txid :: txid()}).
+
+-type vectorclock() :: vectorclock:vectorclock().
+-type txid() :: #tx_id{}.
+-type clocksi_payload() :: #clocksi_payload{}.
+
 -type client_op() :: {update, {key(), type(), op()}} | {read, {key(), type()}} | {prepare, term()} | commit.
 -type crdt() :: term().
 -type val() :: term().

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,6 @@
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "git://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
     {antidote_crdt, ".*", {git, "git://github.com/syncfree/antidote_crdt", {tag, "0.0.4"}}},
-    {antidote_utils, {git, "git://github.com/syncfree/antidote_utils", {tag, "0.2.0"}}},
     {rand_compat, {git, "https://github.com/lasp-lang/rand_compat.git", {ref, "b2cf40b6ef14a5d7fbc67276e9164de7cc7c7906"}}}
 ]}.
 

--- a/src/antidote.app.src
+++ b/src/antidote.app.src
@@ -11,7 +11,6 @@
                   riak_api,
                   riak_core,
                   antidote_crdt,
-                  antidote_utils,
                   cuttlefish,
                   riak_dt,
                   antidote_pb,

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -1,0 +1,205 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(vector_orddict).
+-include("antidote.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type vector_orddict() :: {[{vectorclock(),term()}],non_neg_integer()}.
+-type nonempty_vector_orddict() :: {[{vectorclock(),term()}, ...],non_neg_integer()}.
+
+-export_type([vector_orddict/0,nonempty_vector_orddict/0]).
+
+-export([new/0,
+  get_smaller/2,
+  get_smaller_from_id/3,
+  insert/3,
+  insert_bigger/3,
+  sublist/3,
+  size/1,
+  to_list/1,
+  from_list/1,
+  first/1,
+  last/1,
+  filter/2]).
+
+
+%% @doc The vector orddict is an ordered dictionary used to store materialized snapshots whose order
+%%      is described by vectorclocks.
+%%      Note that the elements are stored in a sorted list going from big to small (left to right).
+-spec new() -> {[],0}.
+new() ->
+  {[],0}.
+
+-spec get_smaller(vectorclock(),vector_orddict()) -> {undefined | {vectorclock(),term()},boolean()}.
+get_smaller(Vector,{List,_Size}) ->
+  get_smaller_internal(Vector,List,true).
+
+-spec get_smaller_internal(vectorclock(),[{vectorclock(),term()}],boolean()) -> {undefined | {vectorclock(),term()},boolean()}.
+get_smaller_internal(_Vector,[],IsFirst) ->
+  {undefined,IsFirst};
+get_smaller_internal(Vector,[{FirstClock,FirstVal}|Rest],IsFirst) ->
+  case vectorclock:le(FirstClock,Vector) of
+    true ->
+      {{FirstClock,FirstVal},IsFirst};
+    false ->
+      get_smaller_internal(Vector,Rest,false)
+  end.
+
+-spec get_smaller_from_id(term(),clock_time(),vector_orddict()) -> undefined | {vectorclock(),term()}.
+get_smaller_from_id(_Id,_Time,{_List,Size}) when Size == 0 ->
+  undefined;
+get_smaller_from_id(Id,Time,{List,_Size}) ->
+  get_smaller_from_id_internal(Id,Time,List).
+
+-spec get_smaller_from_id_internal(term(),clock_time(),[{vectorclock,term()}, ...]) -> undefined | {vectorclock(),term()}.
+get_smaller_from_id_internal(_Id,_Time,[]) ->
+  undefined;
+get_smaller_from_id_internal(Id,Time,[{Clock,Val}|Rest]) ->
+  ValTime = vectorclock:get_clock_of_dc(Id,Clock),
+  case ValTime =< Time of
+    true ->
+      {Clock,Val};
+    false ->
+      get_smaller_from_id_internal(Id,Time,Rest)
+  end.
+
+-spec insert(vectorclock(),term(),vector_orddict()) -> vector_orddict().
+insert(Vector,Val,{List,Size}) ->
+  insert_internal(Vector,Val,List,Size+1,[]).
+
+-spec insert_internal(vectorclock(),term(),[{vectorclock(),term()}],non_neg_integer(),[{vectorclock(),term()}]) -> vector_orddict().
+insert_internal(Vector,Val,[],Size,PrevList) ->
+  {lists:reverse([{Vector,Val}|PrevList]),Size};
+
+insert_internal(Vector,Val,[{FirstClock,FirstVal}|Rest],Size,PrevList) ->
+  case vectorclock:all_dots_greater(Vector,FirstClock) of
+    true ->
+      {lists:reverse(PrevList,[{Vector,Val}|[{FirstClock,FirstVal}|Rest]]),Size};
+    %%PrevList;
+    false ->
+      insert_internal(Vector,Val,Rest,Size,[{FirstClock,FirstVal}|PrevList])
+  end.
+
+
+-spec insert_bigger(vectorclock(),term(),vector_orddict()) -> nonempty_vector_orddict().
+insert_bigger(Vector,Val,{List,Size}) ->
+  insert_bigger_internal(Vector,Val,List,Size).
+
+-spec insert_bigger_internal(vectorclock(),term(),[{vectorclock(),term()}],non_neg_integer()) -> nonempty_vector_orddict().
+insert_bigger_internal(Vector,Val,[],0) ->
+  {[{Vector,Val}],1};
+
+insert_bigger_internal(Vector,Val,[{FirstClock,FirstVal}|Rest],Size) ->
+  case not vectorclock:le(Vector,FirstClock) of
+    true ->
+      {[{Vector,Val}|[{FirstClock,FirstVal}|Rest]],Size+1};
+    false ->
+      {[{FirstClock,FirstVal}|Rest],Size}
+  end.
+
+-spec sublist(vector_orddict(),non_neg_integer(),non_neg_integer()) -> vector_orddict().
+sublist({List,_Size}, Start, Len) ->
+  Res = lists:sublist(List,Start,Len),
+  {Res,length(Res)}.
+
+-spec size(vector_orddict()) -> non_neg_integer().
+size({_List,Size}) ->
+  Size.
+
+-spec to_list(vector_orddict()) -> [{vectorclock(),term()}].
+to_list({List,_Size}) ->
+  List.
+
+-spec from_list([{vectorclock(),term()}]) -> vector_orddict().
+from_list(List) ->
+  {List,length(List)}.
+
+-spec first(vector_orddict()) -> {vectorclock(), term()}.
+first({[First|_Rest],_Size}) ->
+  First.
+
+-spec last(vector_orddict()) -> {vectorclock(), term()}.
+last({List,_Size}) ->
+  lists:last(List).
+
+-spec filter(fun((term()) -> boolean()),vector_orddict()) -> vector_orddict().
+filter(Fun,{List,_Size}) ->
+  Result = lists:filter(Fun,List),
+  {Result,length(List)}.
+
+
+-ifdef(TEST).
+
+vector_oddict_get_smaller_from_id_test() ->
+  %% Fill up the vector
+  Vdict0 = vector_orddict:new(),
+  CT1 = vectorclock:from_list([{dc1,4},{dc2,4}]),
+  Vdict1 = vector_orddict:insert(CT1, 1,Vdict0),
+  CT2 = vectorclock:from_list([{dc1,8},{dc2,8}]),
+  Vdict2 = vector_orddict:insert(CT2, 2, Vdict1),
+  CT3 = vectorclock:from_list([{dc1,1},{dc2,10}]),
+  Vdict3 = vector_orddict:insert(CT3, 3, Vdict2),
+
+  %% Check you get the correct smaller snapshot
+  ?assertEqual(undefined, vector_orddict:get_smaller_from_id(dc1,0,Vdict0)),
+  ?assertEqual(undefined, vector_orddict:get_smaller_from_id(dc1,0,Vdict3)),
+  ?assertEqual({CT3,3}, vector_orddict:get_smaller_from_id(dc1,1,Vdict3)),
+  ?assertEqual({CT2,2}, vector_orddict:get_smaller_from_id(dc2,9,Vdict3)).
+
+
+vector_orddict_get_smaller_test() ->
+  %% Fill up the vector
+  Vdict0 = vector_orddict:new(),
+  CT1 = vectorclock:from_list([{dc1,4},{dc2,4}]),
+  Vdict1 = vector_orddict:insert(CT1, 1,Vdict0),
+  CT2 = vectorclock:from_list([{dc1,8},{dc2,8}]),
+  Vdict2 = vector_orddict:insert(CT2, 2, Vdict1),
+  CT3 = vectorclock:from_list([{dc1,1},{dc2,10}]),
+  Vdict3 = vector_orddict:insert(CT3, 3, Vdict2),
+
+  %% Check you get the correct smaller snapshot
+  ?assertEqual({undefined,false}, vector_orddict:get_smaller(vectorclock:from_list([{dc1,0},{dc2,0}]),Vdict3)),
+  ?assertEqual({undefined,false}, vector_orddict:get_smaller(vectorclock:from_list([{dc1,1},{dc2,6}]),Vdict3)),
+  ?assertEqual({{CT1,1},false}, vector_orddict:get_smaller(vectorclock:from_list([{dc1,5},{dc2,5}]),Vdict3)),
+  ?assertEqual({{CT2,2},true}, vector_orddict:get_smaller(vectorclock:from_list([{dc1,9},{dc2,9}]),Vdict3)),
+  ?assertEqual({{CT3,3},false}, vector_orddict:get_smaller(vectorclock:from_list([{dc1,3},{dc2,11}]),Vdict3)).
+
+
+
+vector_orddict_insert_bigger_test() ->
+  Vdict0 = vector_orddict:new(),
+  %% Insert to empty dict
+  CT1 = vectorclock:from_list([{dc1,4},{dc2,4}]),
+  Vdict1 = vector_orddict:insert_bigger(CT1, 1,Vdict0),
+  ?assertEqual(1,vector_orddict:size(Vdict1)),
+  %% Should not insert because smaller
+  CT2 = vectorclock:from_list([{dc1,3},{dc2,3}]),
+  Vdict2 = vector_orddict:insert_bigger(CT2, 2, Vdict1),
+  ?assertEqual(1,vector_orddict:size(Vdict2)),
+  %% Should insert because bigger
+  CT3 = vectorclock:from_list([{dc1,6},{dc2,10}]),
+  Vdict3 = vector_orddict:insert_bigger(CT3, 3, Vdict2),
+  ?assertEqual(2,vector_orddict:size(Vdict3)).
+
+
+-endif.

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -1,0 +1,169 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(vectorclock).
+
+-include("antidote.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([
+         get_clock_of_dc/2,
+         set_clock_of_dc/3,
+         from_list/1,
+         new/0,
+         eq/2,
+         all_dots_smaller/2,
+         all_dots_greater/2,
+         le/2,
+         ge/2,
+         gt/2,
+         lt/2,
+         max/1,
+         min/1]).
+
+-export_type([vectorclock/0]).
+
+-spec new() -> vectorclock().
+new() ->
+    dict:new().
+          
+-spec get_clock_of_dc(any(), vectorclock()) -> non_neg_integer().
+get_clock_of_dc(Key, VectorClock) ->
+  case dict:find(Key, VectorClock) of
+    {ok, Value} -> Value;
+    error -> 0
+  end.
+
+-spec set_clock_of_dc(any(), non_neg_integer(), vectorclock()) -> vectorclock().
+set_clock_of_dc(Key, Value, VectorClock) ->
+  dict:store(Key, Value, VectorClock).
+
+-spec from_list([{any(), non_neg_integer()}]) -> vectorclock().
+from_list(List) ->
+    dict:from_list(List).
+
+-spec max([vectorclock()]) -> vectorclock().
+max([]) -> new();
+max([V]) -> V;
+max([V1,V2|T]) -> max([merge(fun erlang:max/2, V1, V2)|T]).
+
+-spec min([vectorclock()]) -> vectorclock().
+min([]) -> new();
+min([V]) -> V;
+min([V1,V2|T]) -> min([merge(fun erlang:min/2, V1, V2)|T]).
+
+-spec merge(fun((non_neg_integer(), non_neg_integer()) -> non_neg_integer()), vectorclock(), vectorclock()) -> vectorclock().
+merge(F, V1, V2) ->
+  AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
+  Func = fun(DC) ->
+    A = get_clock_of_dc(DC, V1),
+    B = get_clock_of_dc(DC, V2),
+    {DC, F(A, B)}
+  end,
+  from_list(lists:map(Func, AllDCs)).
+
+-spec for_all_keys(fun((non_neg_integer(), non_neg_integer()) -> boolean()), vectorclock(), vectorclock()) -> boolean().
+for_all_keys(F, V1, V2) ->
+  %% We could but do not care about duplicate DC keys - finding duplicates is not worth the effort
+  AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
+  Func = fun(DC) ->
+    A = get_clock_of_dc(DC, V1),
+    B = get_clock_of_dc(DC, V2),
+    F(A, B)
+  end,
+  lists:all(Func, AllDCs).
+
+-spec eq(vectorclock(), vectorclock()) -> boolean().
+eq(V1, V2) -> for_all_keys(fun(A, B) -> A == B end, V1, V2).
+
+-spec le(vectorclock(), vectorclock()) -> boolean().
+le(V1, V2) -> for_all_keys(fun(A, B) -> A =< B end, V1, V2).
+
+-spec ge(vectorclock(), vectorclock()) -> boolean().
+ge(V1, V2) -> for_all_keys(fun(A, B) -> A >= B end, V1, V2).
+
+-spec all_dots_smaller(vectorclock(), vectorclock()) -> boolean().
+all_dots_smaller(V1, V2) -> for_all_keys(fun(A, B) -> A < B end, V1, V2).
+
+-spec all_dots_greater(vectorclock(), vectorclock()) -> boolean().
+all_dots_greater(V1, V2) -> for_all_keys(fun(A, B) -> A > B end, V1, V2).
+
+-spec gt(vectorclock(), vectorclock()) -> boolean().
+gt(V1,V2) -> ge(V1,V2) and (not eq(V1,V2)).
+
+-spec lt(vectorclock(), vectorclock()) -> boolean().
+lt(V1,V2) -> le(V1,V2) and (not eq(V1,V2)).
+
+-ifdef(TEST).
+
+vectorclock_test() ->
+    V1 = vectorclock:from_list([{1,5},{2,4},{3,5},{4,6}]),
+    V2 = vectorclock:from_list([{1,4}, {2,3}, {3,4},{4,5}]),
+    V3 = vectorclock:from_list([{1,5}, {2,4}, {3,4},{4,5}]),
+    V4 = vectorclock:from_list([{1,6},{2,3},{3,1},{4,7}]),
+    V5 = vectorclock:from_list([{1,6},{2,7}]),
+    ?assertEqual(all_dots_greater(V1,V2), true),
+    ?assertEqual(all_dots_smaller(V2,V1), true),
+    ?assertEqual(all_dots_greater(V1,V3), false),
+    ?assertEqual(gt(V1,V3), true),
+    ?assertEqual(gt(V1,V1), false),
+    ?assertEqual(ge(V1,V4), false),
+    ?assertEqual(le(V1,V4), false),
+    ?assertEqual(eq(V1,V4), false),
+    ?assertEqual(ge(V1,V5), false).
+
+vectorclock_max_test() ->
+  V1 = vectorclock:from_list([{1, 5}, {2, 4}]),
+  V2 = vectorclock:from_list([{1, 6}, {2, 3}]),
+  V3 = vectorclock:from_list([{1, 3}, {3, 2}]),
+
+  Expected12 = vectorclock:from_list([{1, 6}, {2, 4}]),
+  Expected23 = vectorclock:from_list([{1, 6}, {2, 3}, {3, 2}]),
+  Expected13 = vectorclock:from_list([{1, 5}, {2, 4}, {3, 2}]),
+  Expected123 = vectorclock:from_list([{1, 6}, {2, 4}, {3, 2}]),
+  Unexpected123 = vectorclock:from_list([{1, 5}, {2, 5}, {3, 5}]),
+
+  ?assertEqual(eq(max([V1, V2]), Expected12), true),
+  ?assertEqual(eq(max([V2, V3]), Expected23), true),
+  ?assertEqual(eq(max([V1, V3]), Expected13), true),
+  ?assertEqual(eq(max([V1, V2, V3]), Expected123), true),
+  ?assertEqual(eq(max([V1, V2, V3]), Unexpected123), false).
+
+
+vectorclock_min_test() ->
+  V1 = vectorclock:from_list([{1, 5}, {2, 4}]),
+  V2 = vectorclock:from_list([{1, 6}, {2, 3}]),
+  V3 = vectorclock:from_list([{1, 3}, {3, 2}]),
+
+  Expected12 = vectorclock:from_list([{1, 5}, {2, 3}]),
+  Expected23 = vectorclock:from_list([{1, 3}]),
+  Expected13 = vectorclock:from_list([{1, 3}]),
+  Expected123 = vectorclock:from_list([{1, 3}]),
+  Unexpected123 = vectorclock:from_list([{1, 3}, {2, 3}, {3, 2}]),
+
+  ?assertEqual(eq(min([V1, V2]), Expected12), true),
+  ?assertEqual(eq(min([V2, V3]), Expected23), true),
+  ?assertEqual(eq(min([V1, V3]), Expected13), true),
+  ?assertEqual(eq(min([V1, V2, V3]), Expected123), true),
+  ?assertEqual(eq(min([V1, V2, V3]), Unexpected123), false).
+
+-endif.


### PR DESCRIPTION
This removes the dependency on the antidote_utils library.

- vectorclock-implementations were copied to antidote (both implementations are actually used)
- removed json encoding stuff
- added antidote_utils.hrl declarations to antidote.hrl

I also fixed one type definition from antidote_utils.hrl which caused dialyzer errors in Antidote.
