### PR TITLE
Fix markdown link

### DIFF
--- a/docs/pages/mydoc/setup.md
+++ b/docs/pages/mydoc/setup.md
@@ -185,7 +185,7 @@ Or in a single call:
     {ok, Res, _CommitTime} = antidote:read_objects(ignore, [], [CounterObj]).
     [CounterVal] = Res.
 
-More about the API is described [here](/rawapi.html).
+More about the API is described [here](/antidote/rawapi.html).
 
 Running Tests
 -------------


### PR DESCRIPTION
The current link gives an incorrect one [here](http://syncfree.github.io/antidote/setup.html)