### PR TITLE
Update dependencies to include Flag-CRDTs and reset operations

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
     %%{riak_core, {git, "https://github.com/project-fifo/riak_core", {branch, "fifo-0.7.1"}}},
     {riak_core, "2.2.8", {pkg, riak_core_ng}},
     %% TODO: riak_pb branch "antidote_crdt"
-    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {branch, "antidote-flags"}}},
+    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {tag, "v0.4.0"}}},
     {riak_api, {git, "https://github.com/basho/riak_api", {tag, "2.0.2"}}},
     {erlzmq, {git, "https://github.com/tcrain/erlzmq2", {ref, "f40b84ed2947a2bb0dfdbf2f0e0d006beec54b0b"}}},
     %% antidote_pb is client interface. Needed only for riak_tests.

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
     %%{riak_core, {git, "https://github.com/project-fifo/riak_core", {branch, "fifo-0.7.1"}}},
     {riak_core, "2.2.8", {pkg, riak_core_ng}},
     %% TODO: riak_pb branch "antidote_crdt"
-    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {tag, "v0.3.0"}}},
+    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {branch, "antidote-flags"}}},
     {riak_api, {git, "https://github.com/basho/riak_api", {tag, "2.0.2"}}},
     {erlzmq, {git, "https://github.com/tcrain/erlzmq2", {ref, "f40b84ed2947a2bb0dfdbf2f0e0d006beec54b0b"}}},
     %% antidote_pb is client interface. Needed only for riak_tests.

--- a/rebar.config
+++ b/rebar.config
@@ -3,12 +3,12 @@
     %%{riak_core, {git, "https://github.com/project-fifo/riak_core", {branch, "fifo-0.7.1"}}},
     {riak_core, "2.2.8", {pkg, riak_core_ng}},
     %% TODO: riak_pb branch "antidote_crdt"
-    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {tag, "v0.4.0"}}},
+    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {tag, "v0.4.1"}}},
     {riak_api, {git, "https://github.com/basho/riak_api", {tag, "2.0.2"}}},
     {erlzmq, {git, "https://github.com/tcrain/erlzmq2", {ref, "f40b84ed2947a2bb0dfdbf2f0e0d006beec54b0b"}}},
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "https://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
-    {antidote_crdt, ".*", {git, "https://github.com/syncfree/antidote_crdt", {tag, "0.0.5"}}},
+    {antidote_crdt, ".*", {git, "https://github.com/syncfree/antidote_crdt", {tag, "0.0.6"}}},
     {rand_compat, {git, "https://github.com/lasp-lang/rand_compat.git", {ref, "b2cf40b6ef14a5d7fbc67276e9164de7cc7c7906"}}}
 ]}.
 

--- a/test/pb_client_SUITE.erl
+++ b/test/pb_client_SUITE.erl
@@ -505,6 +505,24 @@ crdt_map_rr_test(_Config) ->
   _Disconnected = antidotec_pb_socket:stop(Pid1).
 
 
+crdt_flag_tests(Config) ->
+    [crdt_flag_test(Config, FlagCrdt) || FlagCrdt <- [antidote_crdt_flag_ew, antidote_crdt_flag_dw]].
+
+crdt_flag_test(_Config, FlagCrdt) ->
+  FlagCrdtBin = erlang:atom_to_binary(FlagCrdt),
+  Key = <<"pb_client_SUITE_", FlagCrdtBin/binary>>,
+  {ok, Pid1} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
+  Bound_object = {Key, FlagCrdt, <<"bucket">>},
+  {ok, Tx1} = antidotec_pb:start_transaction(Pid1, ignore, {}),
+  ok = antidotec_pb:update_objects(Pid1, [{Bound_object, enable, {}}], Tx1),
+  {ok, [Val1]} = antidotec_pb:read_values(Pid1, [Bound_object], Tx1),
+  ok = antidotec_pb:update_objects(Pid1, [{Bound_object, disable, {}}], Tx1),
+  {ok, [Val2]} = antidotec_pb:read_values(Pid1, [Bound_object], Tx1),
+  ok = antidotec_pb:update_objects(Pid1, [{Bound_object, reset, {}}], Tx1),
+  {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx1),
+  ?assertEqual(true, Val1),
+  ?assertEqual(false, Val2),
+  _Disconnected = antidotec_pb_socket:stop(Pid1).
 
 static_transaction_test(_Config) ->
     Key = <<"pb_client_SUITE_static_transaction_test">>,

--- a/test/pb_client_SUITE.erl
+++ b/test/pb_client_SUITE.erl
@@ -44,7 +44,7 @@
   update_set_read_test/1,
   static_transaction_test/1,
   crdt_integer_test/1,
-  update_reg_test/1, crdt_mvreg_test/1, crdt_set_rw_test/1, crdt_map_aw_test/1, crdt_gmap_test/1, crdt_map_rr_test/1]).
+  update_reg_test/1, crdt_mvreg_test/1, crdt_set_rw_test/1, crdt_map_aw_test/1, crdt_gmap_test/1, crdt_map_rr_test/1, crdt_flag_tests/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -88,7 +88,8 @@ all() -> [start_stop_test,
         crdt_gmap_test,
         crdt_map_aw_test,
         update_reg_test,
-        crdt_map_rr_test].
+        crdt_map_rr_test,
+        crdt_flag_tests].
 
 start_stop_test(_Config) ->
     lager:info("Verifying pb connection..."),
@@ -509,19 +510,22 @@ crdt_flag_tests(Config) ->
     [crdt_flag_test(Config, FlagCrdt) || FlagCrdt <- [antidote_crdt_flag_ew, antidote_crdt_flag_dw]].
 
 crdt_flag_test(_Config, FlagCrdt) ->
-  FlagCrdtBin = erlang:atom_to_binary(FlagCrdt),
+  FlagCrdtBin = erlang:atom_to_binary(FlagCrdt, utf8),
   Key = <<"pb_client_SUITE_", FlagCrdtBin/binary>>,
   {ok, Pid1} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
   Bound_object = {Key, FlagCrdt, <<"bucket">>},
   {ok, Tx1} = antidotec_pb:start_transaction(Pid1, ignore, {}),
+  io:format("Bound_object = ~p~n", [Bound_object]),
   ok = antidotec_pb:update_objects(Pid1, [{Bound_object, enable, {}}], Tx1),
   {ok, [Val1]} = antidotec_pb:read_values(Pid1, [Bound_object], Tx1),
-  ok = antidotec_pb:update_objects(Pid1, [{Bound_object, disable, {}}], Tx1),
-  {ok, [Val2]} = antidotec_pb:read_values(Pid1, [Bound_object], Tx1),
-  ok = antidotec_pb:update_objects(Pid1, [{Bound_object, reset, {}}], Tx1),
   {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx1),
-  ?assertEqual(true, Val1),
-  ?assertEqual(false, Val2),
+  {ok, Tx2} = antidotec_pb:start_transaction(Pid1, ignore, {}),
+  ok = antidotec_pb:update_objects(Pid1, [{Bound_object, disable, {}}], Tx2),
+  {ok, [Val2]} = antidotec_pb:read_values(Pid1, [Bound_object], Tx2),
+  ok = antidotec_pb:update_objects(Pid1, [{Bound_object, reset, {}}], Tx2),
+  {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx2),
+  ?assertEqual({flag, true}, Val1),
+  ?assertEqual({flag, false}, Val2),
   _Disconnected = antidotec_pb_socket:stop(Pid1).
 
 static_transaction_test(_Config) ->


### PR DESCRIPTION
- `antidote_crdt` is updated to the latest version including enable-wins- and disable-wins-flags
- `riak_pb` is updated, so that flags can be used via the protocol buffer interface. This also adds the `reset` operation to the protocol buffer interface.