### PR TITLE
fix erlzmq dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
     %% TODO: riak_pb branch "antidote_crdt"
     {riak_pb, {git, "https://github.com/syncfree/riak_pb", {tag, "v0.4.1"}}},
     {riak_api, {git, "https://github.com/basho/riak_api", {tag, "2.0.2"}}},
-    {erlzmq, {git, "https://github.com/tcrain/erlzmq2", {ref, "f40b84ed2947a2bb0dfdbf2f0e0d006beec54b0b"}}},
+    {erlzmq, ".*", {git, "https://github.com/zeromq/erlzmq2"}},
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "https://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
     {antidote_crdt, ".*", {git, "https://github.com/syncfree/antidote_crdt", {tag, "0.0.6"}}},


### PR DESCRIPTION
There appears to be a problem with the zmq dependency: it fails when dowloading a file from http://pkgs.fedoraproject.org (see the [Travis job.](https://travis-ci.org/SyncFree/antidote/jobs/335612622)).  
This commit restores the dependency to its original repository, which uses another URL.