### PR TITLE
Fix monitoring docker-compose.yml

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "9090:9090"
     volumes:
       - ".:/data"
-    command: "-config.file=/data/prometheus.yml"
+    command: "--config.file=/data/prometheus.yml"
     depends_on:
       - antidote
   grafana:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   antidote:
-    image: antidotedb/antidote:local
+    image: antidotedb/antidote:latest
     environment:
       NODE_NAME: "antidote@antidote"
       SHORT_NAME: "true"


### PR DESCRIPTION
These two commits fix the command for the prometheus container (i) and use the latest antidote container instead of the locally compiled one (ii).