### PR TITLE
Renamed CRDT modules

### DIFF
--- a/docs/pages/mydoc/api.md
+++ b/docs/pages/mydoc/api.md
@@ -53,15 +53,15 @@ Calling `antidotec_pb_socket:start(?ADDRESS, ?PORT)` starts this proxy and retur
 
 ```erlang
     %% Information on key, type, and bucket
-    KeyInfo = {Key, antidote_crdt_counter, <<"bucket">>},
+    KeyInfo = {Key, antidote_crdt_counter_pn, <<"bucket">>},
     %% Create a new counter update proxy locally
     Cntr = antidotec_counter:new(0),
     %% Increment the counter by 1
     Obj = antidotec_counter:increment(1, Cntr),
     ok = antidotec_pb:update_objects(Pid, antidotec_counter:to_ops(KeyInfor, Obj), TxId).
 
-    Obj1 = {Key1, antidote_crdt_counter, <<"bucket">>},
-    Obj2 = {Key2, antidote_crdt_counter, <<"bucket">>},
+    Obj1 = {Key1, antidote_crdt_counter_pn, <<"bucket">>},
+    Obj2 = {Key2, antidote_crdt_counter_pn, <<"bucket">>},
     %% Read values of two objects
     {ok, [Val1, Val2]} = antidotec_pb:read_objects(Pid, [Obj1, Obj2], TxId),
     Value = antidotec_counter:value(Val1). %% assuming Obj1 is of type counter
@@ -88,8 +88,8 @@ The following code snippet increments two counters atomically.
     %% Starts pb socket
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
 
-    Counter1 = {Key1, antidote_crdt_counter, Bucket},
-    Counter2 = {Key2, antidote_crdt_counter, Bucket},
+    Counter1 = {Key1, antidote_crdt_counter_pn, Bucket},
+    Counter2 = {Key2, antidote_crdt_counter_pn, Bucket},
     LocalObj = antidotec_counter:increment(Amount, antidotec_counter:new(0)),
 
     {ok, TxId} = antidotec_pb:start_transaction(Pid, term_to_binary(ignore), {}),

--- a/docs/pages/mydoc/commit_hooks.md
+++ b/docs/pages/mydoc/commit_hooks.md
@@ -26,8 +26,8 @@ Pre-commit hooks takes one argument which is the client issued update operation 
 Following is a pre-commit hook which modifies single increment  to increment by two.
 
 ```erlang
-my_increment_hook({ {Key, Bucket}, antidote_crdt_counter, {increment, 1} }) ->
-    {ok, { {Key, Bucket}, antidote_crdt_counter, {increment, 2} }}.
+my_increment_hook({ {Key, Bucket}, antidote_crdt_counter_pn, {increment, 1} }) ->
+    {ok, { {Key, Bucket}, antidote_crdt_counter_pn, {increment, 2} }}.
 ```
 
 ## Post-commit hooks
@@ -44,7 +44,7 @@ Following is a post commit hook which increments a commit-count for every update
 ```erlang
     my_commit_count_hook({ { Key, Bucket }, Type, OP }) ->
         _Result = antidote:update_objects(ignore, [],
-                                          [{ {Key, antidote_crdt_counter, commitcount}, increment, 1}]),
+                                          [{ {Key, antidote_crdt_counter_pn, commitcount}, increment, 1}]),
         {ok, { {Key, Bucket}, Type, OP} }.
 ```
 

--- a/docs/pages/mydoc/log.md
+++ b/docs/pages/mydoc/log.md
@@ -94,7 +94,7 @@ The [tab2list](http://erlang.org/doc/man/ets.html#tab2list-1) function - ```ets:
   29,
   {1,
    {clocksi_payload,{my_counter,my_bucket},
-                    antidote_crdt_counter,1,
+                    antidote_crdt_counter_pn,1,
                     {dict,1,16,16,8,80,48,
                           {[],[],[],[],[],[],[],[],[],...},
                           {{[],[],[],[],[],[],[],...}}},
@@ -103,7 +103,7 @@ The [tab2list](http://erlang.org/doc/man/ets.html#tab2list-1) function - ```ets:
                     {tx_id,1489504668106333,<0.5317.0>}}},
   {2,
    {clocksi_payload,{my_counter,my_bucket},
-                    antidote_crdt_counter,1,
+                    antidote_crdt_counter_pn,1,
                     {dict,1,16,16,8,80,48,
                           {[],[],[],[],[],[],[],[],...},
                           {{[],[],[],[],[],[],...}}},
@@ -133,7 +133,7 @@ The [file2tab](http://erlang.org/doc/man/ets.html#file2tab-2) - ```ets:file2tab(
 Supposing the following interaction with Antidote
 
 ```erlang 
-CounterObj = {my_counter, antidote_crdt_counter, my_bucket},
+CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket},
 CounterVal = rpc:call(Node, antidote, read_objects, [ignore, [], [CounterObj]]),
 {ok, CT}  = rpc:call(Node, antidote, update_objects, [ignore, [], [{CounterObj, increment, 1}]])
 ```
@@ -173,7 +173,7 @@ Contents
   1,
   {1,
    {clocksi_payload,{my_counter,my_bucket},
-                    antidote_crdt_counter,1,
+                    antidote_crdt_counter_pn,1,
                     {dict,1,16,16,8,80,48,
                           {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                           {{[[{'antidote@127.0.0.1',{1490,186897,598677}}|
@@ -193,7 +193,7 @@ Pattern
 ```erlang
 clocksi_payload {
 	key={my_counter,my_bucket}
-	type=antidote_crdt_counter
+	type=antidote_crdt_counter_pn
 	op_param=1
 	snapshot_time={dict,1,16,16,8,80,48, {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}, {{[[{'antidote@127.0.0.1',{1490,186897,598677}}|1490186922302506]],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}}
 	commit_time {
@@ -371,7 +371,7 @@ Update record
           update,
           {update_log_payload,
               {<<"5548">>,<<"antidote_bench_bucket">>},
-              undefined,antidote_crdt_counter,-1}}}}
+              undefined,antidote_crdt_counter_pn,-1}}}}
   ```
 
 Contents

--- a/docs/pages/mydoc/quick_start.md
+++ b/docs/pages/mydoc/quick_start.md
@@ -85,7 +85,7 @@ Start a new transaction and increment the value of a bounded counter. By default
 
 ```erlang
 {ok, TxId} = antidote:start_transaction(ignore, []).
-antidote:update_objects([{ {counter_key, antidote_crdt_bcounter, test_bucket}, increment, {10, client1}}], TxId).
+antidote:update_objects([{ {counter_key, antidote_crdt_counter_b, test_bucket}, increment, {10, client1}}], TxId).
 antidote:commit_transaction(TxId).
 # output: {ok, ...}
 ```
@@ -94,7 +94,7 @@ The counter can be decremented in the replica where it was created:
 
 ```erlang
 {ok, TxId1} = antidote:start_transaction(ignore, []).
-antidote:update_objects([{ {counter_key, antidote_crdt_bcounter, test_bucket}, decrement, {1, client1}}], TxId1).
+antidote:update_objects([{ {counter_key, antidote_crdt_counter_b, test_bucket}, decrement, {1, client1}}], TxId1).
 antidote:commit_transaction(TxId1).
 # output: {ok, ...}
 ```
@@ -103,15 +103,15 @@ And the value of the counter can be read on the other replica (use the other ter
 
 ```erlang
 {ok, TxId} = antidote:start_transaction(ignore, []).
-{ok, [Obj]} = antidote:read_objects([{counter_key, antidote_crdt_bcounter, test_bucket}], TxId).
-antidote_crdt_bcounter:permissions(Obj).
+{ok, [Obj]} = antidote:read_objects([{counter_key, antidote_crdt_counter_b, test_bucket}], TxId).
+antidote_crdt_counter_b:permissions(Obj).
 # output: 9
 ```
 
 But cannot be decremented:
 
 ```erlang
-{error, _} = antidote:update_objects([{ {counter_key, antidote_crdt_bcounter, test_bucket}, decrement, {1, client2}}], TxId).
+{error, _} = antidote:update_objects([{ {counter_key, antidote_crdt_counter_b, test_bucket}, decrement, {1, client2}}], TxId).
 # output: {error,{aborted, ...}}
 ```
 
@@ -120,7 +120,7 @@ After the resources are transfered between nodes, it is possible to decrement th
 
 ```erlang
 {ok, TxId1} = antidote:start_transaction(ignore, []).
-antidote:update_objects([{ {counter_key, antidote_crdt_bcounter, test_bucket}, decrement, {1, client2}}], TxId1).
+antidote:update_objects([{ {counter_key, antidote_crdt_counter_b, test_bucket}, decrement, {1, client2}}], TxId1).
 antidote:commit_transaction(TxId1).
 # output: {ok, ...}
 ```

--- a/docs/pages/mydoc/rawapi.md
+++ b/docs/pages/mydoc/rawapi.md
@@ -17,11 +17,11 @@ The interface of these CRDTs specify the operations and the parameters that can 
 In the following, we specify the supported `{operation(), op_param()}` pair for each of the supported CRDTs. 
 The first element in the tuple specifies the update operation, and the second item indicates the corresponding parameters.
 
-##### antidote_crdt_counter #####
+##### antidote_crdt_counter_pn #####
     {increment, integer()}
     {decrement, integer()}
 
-##### antidote_crdt_orset #####
+##### antidote_crdt_set_aw #####
     {add, term()}
     {remove, term()}
     {add_all, [term()]}
@@ -33,11 +33,11 @@ The first element in the tuple specifies the update operation, and the second it
     {add_all, {[term()], actor()}}
     {remove_all, {[term()], actor()}}
 
-##### antidote_crdt_lwwreg #####
+##### antidote_crdt_register_lww #####
     {assign, {term(), non_neg_integer()}}
     {assign, term()}.
 
-##### antidote_crdt_map #####
+##### antidote_crdt_map_rr #####
     {update, {[map_field_update() | map_field_op()], actorordot()}}.
 
     -type actorordot() :: riak_dt:actor() | riak_dt:dot().
@@ -46,7 +46,7 @@ The first element in the tuple specifies the update operation, and the second it
     -type crdt_op() :: term(). %% Valid riak_dt updates
     -type field() :: term()
 
-##### antidote_crdt_mvreg #####
+##### antidote_crdt_register_mv #####
     {assign, {term(), non_neg_integer()}}
     {assign, term()}
     {propagate, {term(), non_neg_integer()}}
@@ -84,7 +84,7 @@ The interface of interactive transaction is:
 #### Example ####
 
 ```erlang
-     CounterObj = {my_counter, antidote_crdt_counter, my_bucket},
+     CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket},
 
      %% Read and increment counter by 1
      {ok, TxId} = rpc:call(Node, antidote, start_transaction, [ignore, []]),
@@ -119,8 +119,8 @@ It is not possible to read and update in the same transaction.
 #### Example ####
 
 ```erlang
-    CounterObj = {my_counter, antidote_crdt_counter, my_bucket},
-    SetObj = {my_set, antidote_crdt_orset, my_bucket},
+    CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket},
+    SetObj = {my_set, antidote_crdt_set_aw, my_bucket},
     {ok, CT1} = rpc:call(Node, antidote, update_objects, [ignore, [], [{CounterObj, increment, 1}]]),
     {ok, Result, CT2} = rpc:call(Node, antidote, read_objects, [CT1, [], [CounterObj, SetObj]]),
     [CounterVal, SetVal] = Result.

--- a/docs/pages/mydoc/setup.md
+++ b/docs/pages/mydoc/setup.md
@@ -159,21 +159,21 @@ Start a node (if you haven't done it yet):
 
 Perform a write operation (example):
 
-        CounterObj = {my_counter, antidote_crdt_counter, my_bucket}.
+        CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket}.
         {ok, TxId} = antidote:start_transaction(ignore, []).
         ok = antidote:update_objects([{CounterObj, increment, 1}], TxId).
         {ok, _CommitTime} = antidote:commit_transaction(TxId).
 
 You can also update objects with a single call as follows:
 
-      CounterObj = {my_counter, antidote_crdt_counter, my_bucket}.
+      CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket}.
       {ok, _CommitTime} = antidote:update_objects(ignore, [], [{CounterObj, increment, 1}]).
 
 #### Reading
 
 Perform a read operation (example):
 
-      CounterObj = {my_counter, antidote_crdt_counter, my_bucket}.
+      CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket}.
       {ok, TxId} = antidote:start_transaction(ignore, []).
       {ok, [CounterVal]} = antidote:read_objects([CounterObj], TxId).
       {ok, _CommitTime3} = antidote:commit_transaction(TxId).
@@ -181,7 +181,7 @@ Perform a read operation (example):
 
 Or in a single call:
 
-    CounterObj = {my_counter, antidote_crdt_counter, my_bucket}.
+    CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket}.
     {ok, Res, _CommitTime} = antidote:read_objects(ignore, [], [CounterObj]).
     [CounterVal] = Res.
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,12 +2,12 @@
     {lager, "3.5.2"},
     {riak_core, "3.0.9", {pkg, riak_core_ng}},
     %% TODO: riak_pb branch "antidote_crdt"
-    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {tag, "v0.4.1"}}},
+    {riak_pb, {git, "https://github.com/syncfree/riak_pb", {tag, "v0.5.1"}}},
     {riak_api, {git, "https://github.com/basho/riak_api", {tag, "2.0.2"}}},
     {erlzmq, ".*", {git, "https://github.com/zeromq/erlzmq2"}},
     %% antidote_pb is client interface. Needed only for riak_tests.
     {antidote_pb, {git, "https://github.com/syncfree/antidote_pb", {tag, "v0.1.0"}}},
-    {antidote_crdt, ".*", {git, "https://github.com/syncfree/antidote_crdt", {tag, "0.0.6"}}},
+    {antidote_crdt, ".*", {git, "https://github.com/syncfree/antidote_crdt", {tag, "v0.1.0"}}},
     {rand_compat, "0.0.3"}, 
     % {rand_compat, {git, "https://github.com/lasp-lang/rand_compat.git", {ref, "b2cf40b6ef14a5d7fbc67276e9164de7cc7c7906"}}},
     % expose metric for prometheus as HTTP-API
@@ -130,7 +130,7 @@
         #{regex => "^[a-z]([a-z0-9]*_?)*(_SUITE)?$",
           ignore => []}
       },
-      % Can be added back if antidote_crdt_bcounter:localPermissions is renamed
+      % Can be added back if antidote_crdt_counter_b:localPermissions is renamed
       %{
       %  elvis_style,
       %  function_naming_convention,

--- a/src/antidote_hooks.erl
+++ b/src/antidote_hooks.erl
@@ -141,11 +141,11 @@ test_commit_hook(Object) ->
     lager:info("Executing test commit hook"),
     {ok, Object}.
 
-test_increment_hook({{Key, Bucket}, antidote_crdt_counter, {increment, 1}}) ->
-    {ok, {{Key, Bucket}, antidote_crdt_counter, {increment, 2}}}.
+test_increment_hook({{Key, Bucket}, antidote_crdt_counter_pn, {increment, 1}}) ->
+    {ok, {{Key, Bucket}, antidote_crdt_counter_pn, {increment, 2}}}.
 
 test_post_hook({{Key, Bucket}, Type, OP}) ->
-    {ok, _CT} = antidote:update_objects(ignore, [], [{{Key, antidote_crdt_counter, commitcount}, increment, 1}]),
+    {ok, _CT} = antidote:update_objects(ignore, [], [{{Key, antidote_crdt_counter_pn, commitcount}, increment, 1}]),
     {ok, {{Key, Bucket}, Type, OP}}.
 
 -endif.

--- a/src/bcounter_mgr.erl
+++ b/src/bcounter_mgr.erl
@@ -47,7 +47,7 @@
 
 -record(state, {req_queue, last_transfers, transfer_timer}).
 -define(LOG_UTIL, log_utilities).
--define(DATA_TYPE, antidote_crdt_bcounter).
+-define(DATA_TYPE, antidote_crdt_counter_b).
 
 
 

--- a/src/clocksi_downstream.erl
+++ b/src/clocksi_downstream.erl
@@ -50,7 +50,7 @@ generate_downstream_op(Transaction, IndexNode, Key, Type, Update, WriteSet, Inte
 
         Snapshot ->
             case Type of
-                antidote_crdt_bcounter ->
+                antidote_crdt_counter_b ->
                     %% bcounter data-type.
                     bcounter_mgr:generate_downstream(Key, Update, Snapshot);
 

--- a/src/clocksi_interactive_tx_coord_fsm.erl
+++ b/src/clocksi_interactive_tx_coord_fsm.erl
@@ -1037,11 +1037,11 @@ read_single_fail_test(Pid) ->
 
 read_success_test(Pid) ->
     fun() ->
-        {ok, State} = gen_fsm:sync_send_event(Pid, {read, {counter, antidote_crdt_counter}}, infinity),
+        {ok, State} = gen_fsm:sync_send_event(Pid, {read, {counter, antidote_crdt_counter_pn}}, infinity),
         ?assertEqual({ok, 2},
-            {ok, antidote_crdt_counter:value(State)}),
+            {ok, antidote_crdt_counter_pn:value(State)}),
         ?assertEqual({ok, [a]},
-            gen_fsm:sync_send_event(Pid, {read, {set, antidote_crdt_gset}}, infinity)),
+            gen_fsm:sync_send_event(Pid, {read, {set, antidote_crdt_set_go}}, infinity)),
         ?assertEqual({ok, mock_value},
             gen_fsm:sync_send_event(Pid, {read, {mock_type, mock_partition_fsm}}, infinity)),
         ?assertMatch({ok, _}, gen_fsm:sync_send_event(Pid, {prepare, empty}, infinity))

--- a/src/clocksi_materializer.erl
+++ b/src/clocksi_materializer.erl
@@ -279,7 +279,7 @@ materialize_eager(Type, Snapshot, Ops) ->
 -ifdef(TEST).
 
 materializer_clocksi_test()->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     PNCounter = new(Type),
     ?assertEqual(0, Type:value(PNCounter)),
     %%  need to add the snapshot time for these for the test to pass
@@ -319,7 +319,7 @@ materializer_clocksi_test()->
 %% the left and right of it in the list are taken.  When this snapshot is then used for a future
 %% read with a different timestamp, this missing value must be checked.
 materializer_missing_op_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     PNCounter = new(Type),
     ?assertEqual(0, Type:value(PNCounter)),
     Op1 = #clocksi_payload{key = abc, type = Type,
@@ -354,7 +354,7 @@ materializer_missing_op_test() ->
 %% This can happen for example if an update is commited before the DCs have been connected.
 %% It ensures that when we read using a snapshot with and without all the DCs we still include the correct updates.
 materializer_missing_dc_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     PNCounter = new(Type),
     ?assertEqual(0, Type:value(PNCounter)),
     Op1 = #clocksi_payload{key = abc, type = Type,
@@ -398,7 +398,7 @@ materializer_missing_dc_test() ->
     ?assertEqual({4, vectorclock:from_list([{1, 3}, {2, 2}])}, {Type:value(PNCounter3), CommitTime3}).
 
 materializer_clocksi_concurrent_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     PNCounter = new(Type),
     ?assertEqual(0, Type:value(PNCounter)),
     Op1 = #clocksi_payload{key = abc, type = Type,
@@ -433,7 +433,7 @@ materializer_clocksi_concurrent_test() ->
 
 %% Testing gcounter with empty update log
 materializer_clocksi_noop_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     PNCounter = new(Type),
     ?assertEqual(0, Type:value(PNCounter)),
     Ops = [],
@@ -444,7 +444,7 @@ materializer_clocksi_noop_test() ->
     ?assertEqual(0, Type:value(PNCounter3)).
 
 materializer_eager_clocksi_test()->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     PNCounter = new(Type),
     ?assertEqual(0, Type:value(PNCounter)),
     % test - no ops
@@ -460,7 +460,7 @@ materializer_eager_clocksi_test()->
     ?assertEqual(10, Type:value(PNCounter3)).
 
 is_op_in_snapshot_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Op1 = #clocksi_payload{key = abc, type = Type,
                            op_param = {increment, 2},
                            commit_time = {dc1, 1}, txid = 1, snapshot_time=vectorclock:from_list([{dc1, 1}])},

--- a/src/materializer.erl
+++ b/src/materializer.erl
@@ -89,7 +89,7 @@ check_operation(Op) ->
 
 %% Testing update with pn_counter.
 update_pncounter_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Counter = create_snapshot(Type),
     ?assertEqual(0, Type:value(Counter)),
     Op = 1,
@@ -98,7 +98,7 @@ update_pncounter_test() ->
 
 %% Testing pn_counter with update log
 materializer_counter_withlog_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Counter = create_snapshot(Type),
     ?assertEqual(0, Type:value(Counter)),
     Ops = [1,
@@ -111,7 +111,7 @@ materializer_counter_withlog_test() ->
 
 %% Testing counter with empty update log
 materializer_counter_emptylog_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Counter = create_snapshot(Type),
     ?assertEqual(0, Type:value(Counter)),
     Ops = [],
@@ -124,27 +124,27 @@ materializer_error_nocreate_test() ->
 
 %% Testing crdt with invalid update operation
 materializer_error_invalidupdate_test() ->
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Counter = create_snapshot(Type),
     ?assertEqual(0, Type:value(Counter)),
     Ops = [{non_existing_op_type, {non_existing_op, actor1}}],
     ?assertEqual({error, {unexpected_operation,
                     {non_existing_op_type, {non_existing_op, actor1}},
-                    antidote_crdt_counter}},
+                    antidote_crdt_counter_pn}},
                  materialize_eager(Type, Counter, Ops)).
 
 %% Testing that the function check_operations works properly
 check_operations_test() ->
     Operations =
-        [{read, {key1, antidote_crdt_counter}},
-         {update, {key1, antidote_crdt_counter, increment}}
+        [{read, {key1, antidote_crdt_counter_pn}},
+         {update, {key1, antidote_crdt_counter_pn, increment}}
         ],
     ?assertEqual(ok, check_operations(Operations)),
 
-    Operations2 = [{read, {key1, antidote_crdt_counter}},
-        {update, {key1, antidote_crdt_counter, {{add, elem}, a}}},
-        {update, {key2, antidote_crdt_counter, {increment, a}}},
-        {read, {key1, antidote_crdt_counter}}],
+    Operations2 = [{read, {key1, antidote_crdt_counter_pn}},
+        {update, {key1, antidote_crdt_counter_pn, {{add, elem}, a}}},
+        {update, {key2, antidote_crdt_counter_pn, {increment, a}}},
+        {read, {key1, antidote_crdt_counter_pn}}],
     ?assertMatch({error, _}, check_operations(Operations2)).
 
 -endif.

--- a/src/materializer_vnode.erl
+++ b/src/materializer_vnode.erl
@@ -720,7 +720,7 @@ gc_test() ->
     SnapshotCache = ets:new(snapshot_cache, [set]),
     Key = mycount,
     DC1 = 1,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
 
     %% Make 10 snapshots
     MatState = #mat_state{ops_cache = OpsCache, snapshot_cache = SnapshotCache},
@@ -788,7 +788,7 @@ large_list_test() ->
     SnapshotCache = ets:new(snapshot_cache, [set]),
     Key = mycount,
     DC1 = 1,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     MatState = #mat_state{ops_cache = OpsCache, snapshot_cache = SnapshotCache},
 
     %% Make 1000 updates to grow the list, whithout generating a snapshot to perform the gc
@@ -811,7 +811,7 @@ large_list_test() ->
 
 generate_payload(SnapshotTime, CommitTime, Prev, _Name) ->
     Key = mycount,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     DC1 = 1,
 
     {ok, Op1} = Type:downstream({increment, 1}, Prev),
@@ -827,7 +827,7 @@ seq_write_test() ->
     OpsCache = ets:new(ops_cache, [set]),
     SnapshotCache = ets:new(snapshot_cache, [set]),
     Key = mycount,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     DC1 = 1,
     S1 = Type:new(),
     MatState = #mat_state{ops_cache = OpsCache, snapshot_cache = SnapshotCache},
@@ -864,7 +864,7 @@ multipledc_write_test() ->
     OpsCache = ets:new(ops_cache, [set]),
     SnapshotCache = ets:new(snapshot_cache, [set]),
     Key = mycount,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     DC1 = 1,
     DC2 = 2,
     S1 = Type:new(),
@@ -903,7 +903,7 @@ concurrent_write_test() ->
     OpsCache = ets:new(ops_cache, [set]),
     SnapshotCache = ets:new(snapshot_cache, [set]),
     Key = mycount,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     DC1 = local,
     DC2 = remote,
     S1 = Type:new(),
@@ -949,7 +949,7 @@ read_nonexisting_key_test() ->
     OpsCache = ets:new(ops_cache, [set]),
     SnapshotCache = ets:new(snapshot_cache, [set]),
     MatState = #mat_state{ops_cache = OpsCache, snapshot_cache = SnapshotCache},
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     {ok, ReadResult} = internal_read(key, Type, vectorclock:from_list([{dc1, 1}, {dc2, 0}]), ignore, [], false, MatState),
     ?assertEqual(0, Type:value(ReadResult)).
 

--- a/src/mock_partition_fsm.erl
+++ b/src/mock_partition_fsm.erl
@@ -120,13 +120,13 @@ read_data_item(_IndexNode, _Transaction, Key, _Type, _Ws) ->
         read_fail ->
             {error, mock_read_fail};
         counter ->
-            Counter = antidote_crdt_counter:new(),
-            {ok, Counter1} = antidote_crdt_counter:update(1, Counter),
-            {ok, Counter2} = antidote_crdt_counter:update(1, Counter1),
+            Counter = antidote_crdt_counter_pn:new(),
+            {ok, Counter1} = antidote_crdt_counter_pn:update(1, Counter),
+            {ok, Counter2} = antidote_crdt_counter_pn:update(1, Counter1),
             {ok, Counter2};
         set ->
-            Set = antidote_crdt_gset:new(),
-            {ok, Set1} = antidote_crdt_gset:update([a], Set),
+            Set = antidote_crdt_set_go:new(),
+            {ok, Set1} = antidote_crdt_set_go:update([a], Set),
             {ok, Set1};
         _ ->
             {ok, mock_value}

--- a/test/antidote_SUITE.erl
+++ b/test/antidote_SUITE.erl
@@ -82,7 +82,7 @@ dummy_test(Config) ->
     [Node1, Node2 | _Nodes] = proplists:get_value(nodes, Config),
     ct:print("Test on ~p!", [Node1]),
     Key = antidote_key,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Bucket = antidote_bucket,
     Object = {Key, Type, Bucket},
     Update = {Object, increment, 1},
@@ -104,7 +104,7 @@ dummy_test(Config) ->
 static_txn_single_object(Config) ->
     [Node1 | _Nodes] = proplists:get_value(nodes, Config),
     Key = antidote_key_static1,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Bucket = antidote_bucket,
     Object = {Key, Type, Bucket},
     Update = {Object, increment, 1},
@@ -116,7 +116,7 @@ static_txn_single_object(Config) ->
 static_txn_single_object_clock(Config) ->
     [Node1 | _Nodes] = proplists:get_value(nodes, Config),
     Key = antidote_key_static2,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Bucket = antidote_bucket,
     Object = {Key, Type, Bucket},
     Update = {Object, increment, 1},
@@ -130,7 +130,7 @@ static_txn_single_object_clock(Config) ->
 
 static_txn_multi_objects(Config) ->
     [Node1 | _Nodes] = proplists:get_value(nodes, Config),
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Bucket = antidote_bucket,
     Keys = [antidote_static_m1, antidote_static_m2, antidote_static_m3, antidote_static_m4],
     IncValues = [1, 2, 3, 4],
@@ -148,7 +148,7 @@ static_txn_multi_objects(Config) ->
 
 static_txn_multi_objects_clock(Config) ->
     [Node1 | _Nodes] = proplists:get_value(nodes, Config),
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Bucket = antidote_bucket,
     Keys = [antidote_static_mc1, antidote_static_mc2, antidote_static_mc3, antidote_static_mc4],
     IncValues = [1, 2, 3, 4],
@@ -170,7 +170,7 @@ static_txn_multi_objects_clock(Config) ->
 
 interactive_txn(Config) ->
     [Node | _Nodes] = proplists:get_value(nodes, Config),
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Bucket = antidote_bucket,
     Keys = [antidote_int_m1, antidote_int_m2, antidote_int_m3, antidote_int_m4],
     IncValues = [1, 2, 3, 4],
@@ -221,7 +221,7 @@ random_test(Config) ->
     NumWrites = 100,
     ListIds = [rand_compat:uniform(N) || _ <- lists:seq(1, NumWrites)], % TODO avoid nondeterminism in tests
 
-    Obj = {log_test_key1, antidote_crdt_counter, antidote_bucket},
+    Obj = {log_test_key1, antidote_crdt_counter_pn, antidote_bucket},
     F = fun(Elem) ->
                 Node = lists:nth(Elem, Nodes),
                 ct:print("Inc at node: ~p", [Node]),

--- a/test/append_SUITE.erl
+++ b/test/append_SUITE.erl
@@ -45,7 +45,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
--define(TYPE, antidote_crdt_counter).
+-define(TYPE, antidote_crdt_counter_pn).
 -define(BUCKET, append_bucket).
 
 init_per_suite(Config) ->

--- a/test/bcountermgr_SUITE.erl
+++ b/test/bcountermgr_SUITE.erl
@@ -41,7 +41,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
 
--define(TYPE, antidote_crdt_bcounter).
+-define(TYPE, antidote_crdt_counter_b).
 -define(BUCKET, bcounter_bucket).
 -define(RETRY_COUNT, 5).
 
@@ -129,7 +129,7 @@ test_dec_multi_success1(Config) ->
 conditional_write_test_run(Config) ->
     Nodes = proplists:get_value(nodes, Config),
     [Node1, Node2 | _OtherNodes] = Nodes,
-    Type = antidote_crdt_bcounter,
+    Type = antidote_crdt_counter_b,
     Key = bcounter6_mgr,
     BObj = {Key, Type, ?BUCKET},
 

--- a/test/commit_hooks_SUITE.erl
+++ b/test/commit_hooks_SUITE.erl
@@ -94,7 +94,7 @@ execute_hook_test(Config) ->
     ok = rpc:call(Node, antidote, register_pre_hook,
                   [Bucket, antidote_hooks, test_increment_hook]),
 
-    Bound_object = {hook_key, antidote_crdt_counter, Bucket},
+    Bound_object = {hook_key, antidote_crdt_counter_pn, Bucket},
     {ok, TxId} = rpc:call(Node, antidote, start_transaction, [ignore, []]),
     ct:print("Txid ~p", [TxId]),
     ok = rpc:call(Node, antidote, update_objects, [[{Bound_object, increment, 1}], TxId]),
@@ -113,12 +113,12 @@ execute_post_hook_test(Config) ->
     ok = rpc:call(Node, antidote, register_post_hook,
                    [Bucket, antidote_hooks, test_post_hook]),
 
-    Bound_object = {post_hook_key, antidote_crdt_counter, Bucket},
+    Bound_object = {post_hook_key, antidote_crdt_counter_pn, Bucket},
     {ok, TxId} =  rpc:call(Node, antidote, start_transaction, [ignore, []]),
     ok = rpc:call(Node, antidote, update_objects, [[{Bound_object, increment, 1}], TxId]),
     {ok, CT} = rpc:call(Node, antidote, commit_transaction, [TxId]),
 
-    CommitCount = {post_hook_key, antidote_crdt_counter, commitcount},
+    CommitCount = {post_hook_key, antidote_crdt_counter_pn, commitcount},
     {ok, TxId2} = rpc:call(Node, antidote, start_transaction, [CT, []]),
     Res = rpc:call(Node, antidote, read_objects, [[CommitCount], TxId2]),
     rpc:call(Node, antidote, commit_transaction, [TxId2]),
@@ -131,7 +131,7 @@ execute_prehooks_static_txn_test(Config) ->
     ok = rpc:call(Node, antidote, register_pre_hook,
                   [Bucket, antidote_hooks, test_increment_hook]),
 
-    Bound_object = {prehook_key, antidote_crdt_counter, Bucket},
+    Bound_object = {prehook_key, antidote_crdt_counter_pn, Bucket},
     {ok, CT} = rpc:call(Node, antidote, update_objects, [ignore, [], [{Bound_object, increment, 1}]]),
 
     {ok, TxId2} = rpc:call(Node, antidote, start_transaction, [CT, []]),
@@ -146,10 +146,10 @@ execute_posthooks_static_txn_test(Config) ->
     ok = rpc:call(Node, antidote, register_post_hook,
                   [Bucket, antidote_hooks, test_post_hook]),
 
-    Bound_object = {posthook_static_key, antidote_crdt_counter, Bucket},
+    Bound_object = {posthook_static_key, antidote_crdt_counter_pn, Bucket},
     {ok, CT} = rpc:call(Node, antidote, update_objects, [ignore, [], [{Bound_object, increment, 1}]]),
 
-    CommitCount = {posthook_static_key, antidote_crdt_counter, commitcount},
+    CommitCount = {posthook_static_key, antidote_crdt_counter_pn, commitcount},
     {ok, TxId2} = rpc:call(Node, antidote, start_transaction, [CT, []]),
     Res = rpc:call(Node, antidote, read_objects, [[CommitCount], TxId2]),
     rpc:call(Node, antidote, commit_transaction, [TxId2]),

--- a/test/gr_SUITE.erl
+++ b/test/gr_SUITE.erl
@@ -78,7 +78,7 @@ read_write_test(Config) ->
     lager:info("Single read write test"),
     Nodes = proplists:get_value(nodes, Config),
     Node = hd(Nodes),
-    Bound_object = {gr_rw_key, antidote_crdt_counter, bucket},
+    Bound_object = {gr_rw_key, antidote_crdt_counter_pn, bucket},
     {ok, [0], _} = rpc:call(Node, antidote, read_objects, [ignore, [], [Bound_object]]),
     {ok, _} = rpc:call(Node, antidote, update_objects, [ignore, [], [{Bound_object, increment, 1}]]),
     {ok, Res, _} = rpc:call(Node, antidote, read_objects, [ignore, [], [Bound_object]]),
@@ -88,9 +88,9 @@ read_multiple_test(Config) ->
     lager:info("Snapshot read"),
     Nodes = proplists:get_value(nodes, Config),
     Node = hd(Nodes),
-    O1 = {gr_read_mult_key1, antidote_crdt_counter, bucket},
+    O1 = {gr_read_mult_key1, antidote_crdt_counter_pn, bucket},
     {ok, _} = rpc:call(Node, antidote, update_objects, [ignore, [], [{O1, increment, 1}]]),
-    O2 = {o2, antidote_crdt_counter, bucket},
+    O2 = {o2, antidote_crdt_counter_pn, bucket},
     {ok, CT} = rpc:call(Node, antidote, update_objects, [ignore, [], [{O2, increment, 1}]]),
     {ok, Res, _} = rpc:call(Node, antidote, read_objects, [CT, {}, [O1, O2]]),
     ?assertMatch([1, 1], Res).
@@ -99,8 +99,8 @@ replication_test(Config) ->
     lager:info("Replication Test"),
     [Node1, Node2 | _] = proplists:get_value(nodes, Config),
 
-    O1 = {gr_repl_key1, antidote_crdt_counter, bucket},
-    O2 = {gr_repl_key2, antidote_crdt_counter, bucket},
+    O1 = {gr_repl_key1, antidote_crdt_counter_pn, bucket},
+    O2 = {gr_repl_key2, antidote_crdt_counter_pn, bucket},
     %% Write to DC1
     {ok, _CT1} = rpc:call(Node1, antidote, update_objects, [ignore, [], [{O1, increment, 1}]]),
     %% Write to DC2

--- a/test/inter_dc_repl_SUITE.erl
+++ b/test/inter_dc_repl_SUITE.erl
@@ -77,7 +77,7 @@ simple_replication_test(Config) ->
     [Node1, Node2 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
 
     Key = simple_replication_test,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     update_counters(Node1, [Key], [1], ignore, static),
     update_counters(Node1, [Key], [1], ignore, static),
     {ok, CommitTime} = update_counters(Node1, [Key], [1], ignore, static),
@@ -90,7 +90,7 @@ simple_replication_test(Config) ->
 multiple_keys_test(Config) ->
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Key = multiple_keys_test,
     lists:foreach( fun(_) ->
                            multiple_writes(Node1, Key, Type, 1, 10, rpl)
@@ -129,7 +129,7 @@ causality_test(Config) ->
     %% result set should not contain e
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
-    Type = antidote_crdt_orset,
+    Type = antidote_crdt_set_aw,
     Key = causality_test,
     {ok, CommitTime1} = update_sets(Node1, [Key], [{add, first}], ignore),
     {ok, CommitTime2} = update_sets(Node1, [Key], [{add, second}], CommitTime1),
@@ -148,7 +148,7 @@ atomicity_test(Config) ->
     Key1 = atomicity_test1,
     Key2 = atomicity_test2,
     Key3 = atomicity_test3,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
 
     Caller = self(),
     ContWrite = fun() ->
@@ -216,7 +216,7 @@ check_read(Node, Objects, Expected, Clock, TxId) ->
 
 update_counters(Node, Keys, IncValues, Clock, TxId) ->
     Updates = lists:map(fun({Key, Inc}) ->
-                                {{Key, antidote_crdt_counter, ?BUCKET}, increment, Inc}
+                                {{Key, antidote_crdt_counter_pn, ?BUCKET}, increment, Inc}
                         end,
                         lists:zip(Keys, IncValues)
                        ),
@@ -232,7 +232,7 @@ update_counters(Node, Keys, IncValues, Clock, TxId) ->
 
 update_sets(Node, Keys, Ops, Clock) ->
     Updates = lists:map(fun({Key, {Op, Param}}) ->
-                                {{Key, antidote_crdt_orset, ?BUCKET}, Op, Param}
+                                {{Key, antidote_crdt_set_aw, ?BUCKET}, Op, Param}
                         end,
                         lists:zip(Keys, Ops)
                        ),

--- a/test/log_recovery_SUITE.erl
+++ b/test/log_recovery_SUITE.erl
@@ -67,7 +67,7 @@ read_pncounter_log_recovery_test(Config) ->
         {ok, false} ->
             pass;
         _ ->
-            Type = antidote_crdt_counter,
+            Type = antidote_crdt_counter_pn,
             Key = log_value_test,
             Obj = {Key, Type, bucket},
 

--- a/test/multiple_dcs_SUITE.erl
+++ b/test/multiple_dcs_SUITE.erl
@@ -79,7 +79,7 @@ simple_replication_test(Config) ->
     [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
 
     Key = simple_replication_test_dc,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
 
     update_counters(Node1, [Key], [1], ignore, static),
     update_counters(Node1, [Key], [1], ignore, static),
@@ -108,7 +108,7 @@ parallel_writes_test(Config) ->
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
     Key = parallel_writes_test,
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Pid = self(),
     spawn(?MODULE, multiple_writes, [Node1, Key, Pid]),
     spawn(?MODULE, multiple_writes, [Node2, Key, Pid]),
@@ -157,7 +157,7 @@ failure_test(Config) ->
         {ok, false} ->
             pass;
         _ ->
-            Type = antidote_crdt_counter,
+            Type = antidote_crdt_counter_pn,
             Key = multiplde_dc_failure_test,
 
             update_counters(Node1, [Key], [1], ignore, static),
@@ -193,7 +193,7 @@ failure_test(Config) ->
 blocking_test(Config) ->
     Clusters = proplists:get_value(clusters, Config),
     [Node1, Node2, Node3 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
-    Type = antidote_crdt_counter,
+    Type = antidote_crdt_counter_pn,
     Key = blocking_test,
 
     %% Drop the heartbeat messages at DC3, allowing its
@@ -225,7 +225,7 @@ replicated_set_test(Config) ->
     [Node1, Node2 | _Nodes] =  [ hd(Cluster)|| Cluster <- Clusters ],
 
     Key1 = replicated_set_test,
-    Type = antidote_crdt_orset,
+    Type = antidote_crdt_set_aw,
 
     lager:info("Writing 100 elements to set!!!"),
 
@@ -262,7 +262,7 @@ check_read(Node, Objects, Expected, Clock, TxId) ->
 
 update_counters(Node, Keys, IncValues, Clock, TxId) ->
     Updates = lists:map(fun({Key, Inc}) ->
-                                {{Key, antidote_crdt_counter, ?BUCKET}, increment, Inc}
+                                {{Key, antidote_crdt_counter_pn, ?BUCKET}, increment, Inc}
                         end,
                         lists:zip(Keys, IncValues)
                        ),
@@ -278,7 +278,7 @@ update_counters(Node, Keys, IncValues, Clock, TxId) ->
 
 update_sets(Node, Keys, Ops, Clock) ->
     Updates = lists:map(fun({Key, {Op, Param}}) ->
-                                {{Key, antidote_crdt_orset, ?BUCKET}, Op, Param}
+                                {{Key, antidote_crdt_set_aw, ?BUCKET}, Op, Param}
                         end,
                         lists:zip(Keys, Ops)
                        ),

--- a/test/multiple_dcs_node_failure_SUITE.erl
+++ b/test/multiple_dcs_node_failure_SUITE.erl
@@ -86,7 +86,7 @@ cluster_failure_test(Config) ->
             pass;
         _ ->
             Key = cluster_failure_test,
-            Type = antidote_crdt_counter,
+            Type = antidote_crdt_counter_pn,
 
             update_counters(Node1, [Key], [1], ignore, static),
             update_counters(Node1, [Key], [1], ignore, static),
@@ -135,7 +135,7 @@ multiple_cluster_failure_test(Config) ->
             Node2 = hd(Cluster2),
 
             Key = multiple_cluster_failure_test,
-            Type = antidote_crdt_counter,
+            Type = antidote_crdt_counter_pn,
 
             update_counters(Node1, [Key], [1], ignore, static),
             update_counters(Node1, [Key], [1], ignore, static),
@@ -178,7 +178,7 @@ update_during_cluster_failure_test(Config) ->
         _ ->
 
             Key = update_during_cluster_failure_test,
-            Type = antidote_crdt_counter,
+            Type = antidote_crdt_counter_pn,
 
             update_counters(Node1, [Key], [1], ignore, static),
             update_counters(Node1, [Key], [1], ignore, static),
@@ -238,7 +238,7 @@ check_read(Node, Objects, Expected, Clock, TxId) ->
 
 update_counters(Node, Keys, IncValues, Clock, TxId) ->
     Updates = lists:map(fun({Key, Inc}) ->
-                                {{Key, antidote_crdt_counter, ?BUCKET}, increment, Inc}
+                                {{Key, antidote_crdt_counter_pn, ?BUCKET}, increment, Inc}
                         end,
                         lists:zip(Keys, IncValues)
                        ),

--- a/test/object_log_state_SUITE.erl
+++ b/test/object_log_state_SUITE.erl
@@ -61,7 +61,7 @@ all() -> [object_log_state_test].
 object_log_state_test(Config) ->
     Nodes = proplists:get_value(nodes, Config),
     FirstNode = hd(Nodes),
-    Type = antidote_crdt_orset,
+    Type = antidote_crdt_set_aw,
     Key = object_log_state_test,
     Bucket = object_log_state_bucket,
     BoundObject = {Key, Type, Bucket},
@@ -93,7 +93,7 @@ object_log_state_test(Config) ->
 check_orset_ops([], [], _KeyBucket) ->
     ok;
 check_orset_ops([Val|Rest1],
-        [{_Id, #clocksi_payload{key = KeyBucket, type = antidote_crdt_orset, op_param = [{Val, _Binary, []}]}}
+        [{_Id, #clocksi_payload{key = KeyBucket, type = antidote_crdt_set_aw, op_param = [{Val, _Binary, []}]}}
          | Rest2],
         KeyBucket) ->
     check_orset_ops(Rest1, Rest2, KeyBucket).

--- a/test/pb_client_SUITE.erl
+++ b/test/pb_client_SUITE.erl
@@ -102,7 +102,7 @@ start_stop_test(_Config) ->
 simple_transaction_test(Config) ->
     Nodes = proplists:get_value(nodes, Config),
     Node = hd(Nodes),
-    Bound_object = {pb_client_SUITE_simple_transaction_test, antidote_crdt_counter, bucket},
+    Bound_object = {pb_client_SUITE_simple_transaction_test, antidote_crdt_counter_pn, bucket},
     {ok, TxId} = rpc:call(Node, antidote, start_transaction, [ignore, []]),
     {ok, [0]} = rpc:call(Node, antidote, read_objects, [[Bound_object], TxId]),
     rpc:call(Node, antidote, commit_transaction, [TxId]).
@@ -111,7 +111,7 @@ simple_transaction_test(Config) ->
 read_write_test(Config) ->
     Nodes = proplists:get_value(nodes, Config),
     Node = hd(Nodes),
-    Bound_object = {pb_client_SUITE_read_write_test, antidote_crdt_counter, bucket},
+    Bound_object = {pb_client_SUITE_read_write_test, antidote_crdt_counter_pn, bucket},
     {ok, TxId} = rpc:call(Node, antidote, start_transaction, [ignore, []]),
     {ok, [0]} = rpc:call(Node, antidote, read_objects, [[Bound_object], TxId]),
     ok = rpc:call(Node, antidote, update_objects, [[{Bound_object, increment, 1}], TxId]),
@@ -121,7 +121,7 @@ read_write_test(Config) ->
 %% Single object rea
 get_empty_crdt_test(_Config) ->
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter, <<"bucket">>},
+    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter_pn, <<"bucket">>},
     {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
     {ok, [Val]} = antidotec_pb:read_objects(Pid, [Bound_object], TxId),
     {ok, _} = antidotec_pb:commit_transaction(Pid, TxId),
@@ -130,7 +130,7 @@ get_empty_crdt_test(_Config) ->
 
 client_fail_test(_Config) ->
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter, <<"bucket">>},
+    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter_pn, <<"bucket">>},
     {ok, _TxIdFail} = antidotec_pb:start_transaction(Pid, ignore, {}),
     % Client fails and starts next transaction:
     {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
@@ -142,7 +142,7 @@ client_fail_test(_Config) ->
 
 client_fail_test2(_Config) ->
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter, <<"bucket">>},
+    Bound_object = {<<"pb_client_SUITE_get_empty_crdt_test">>, antidote_crdt_counter_pn, <<"bucket">>},
     {ok, _TxIdFail} = antidotec_pb:start_transaction(Pid, ignore, {}),
     % Client fails and starts next transaction:
     {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
@@ -163,7 +163,7 @@ client_fail_test2(_Config) ->
 pb_test_counter_read_write(_Config) ->
     Key = <<"pb_client_SUITE_pb_test_counter_read_write">>,
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {Key, antidote_crdt_counter, <<"bucket">>},
+    Bound_object = {Key, antidote_crdt_counter_pn, <<"bucket">>},
     {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
     ok = antidotec_pb:update_objects(Pid, [{Bound_object, increment, 1}], TxId),
     {ok, _} = antidotec_pb:commit_transaction(Pid, TxId),
@@ -177,7 +177,7 @@ pb_test_counter_read_write(_Config) ->
 pb_test_set_read_write(_Config) ->
     Key = <<"pb_client_SUITE_pb_test_set_read_write">>,
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {Key, antidote_crdt_orset, <<"bucket">>},
+    Bound_object = {Key, antidote_crdt_set_aw, <<"bucket">>},
     {ok, TxId} = antidotec_pb:start_transaction(Pid, ignore, {}),
     ok = antidotec_pb:update_objects(Pid, [{Bound_object, add, <<"a">>}], TxId),
     {ok, _} = antidotec_pb:commit_transaction(Pid, TxId),
@@ -206,7 +206,7 @@ update_counter_crdt_test(_Config) ->
     update_counter_crdt(Key, Bucket, Amount).
 
 update_counter_crdt(Key, Bucket, Amount) ->
-    BObj = {Key, antidote_crdt_counter, Bucket},
+    BObj = {Key, antidote_crdt_counter_pn, Bucket},
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
     Obj = antidotec_counter:new(),
     Obj2 = antidotec_counter:increment(Amount, Obj),
@@ -222,7 +222,7 @@ update_counter_crdt_and_read_test(_Config) ->
     Key = <<"pb_client_SUITE_update_counter_crdt_and_read_test">>,
     Amount = 15,
     pass = update_counter_crdt(Key, <<"bucket">>, Amount),
-    pass = get_crdt_check_value(Key, antidote_crdt_counter, <<"bucket">>, Amount).
+    pass = get_crdt_check_value(Key, antidote_crdt_counter_pn, <<"bucket">>, Amount).
 
 get_crdt_check_value(Key, Type, Bucket, Expected) ->
     lager:info("Verifying value of updated CRDT..."),
@@ -239,7 +239,7 @@ get_crdt_check_value(Key, Type, Bucket, Expected) ->
 update_set_read_test(_Config) ->
     Key = <<"pb_client_SUITE_update_set_read_test">>,
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {Key, antidote_crdt_orset, <<"bucket">>},
+    Bound_object = {Key, antidote_crdt_set_aw, <<"bucket">>},
     Set = antidotec_set:new(),
     Set1 = antidotec_set:add(<<"a">>, Set),
     Set2 = antidotec_set:add(<<"b">>, Set1),
@@ -262,7 +262,7 @@ update_set_read_test(_Config) ->
 update_reg_test(_Config) ->
     Key = <<"pb_client_SUITE_update_reg_test">>,
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {Key, antidote_crdt_lwwreg, <<"bucket">>},
+    Bound_object = {Key, antidote_crdt_register_lww, <<"bucket">>},
     {ok, TxId} = antidotec_pb:start_transaction(Pid,
                                                 ignore, {}),
     ok = antidotec_pb:update_objects(Pid,
@@ -300,7 +300,7 @@ crdt_integer_test(_Config) ->
 crdt_mvreg_test(_Config) ->
     Key = <<"pb_client_SUITE_crdt_mvreg_test">>,
     {ok, Pid1} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {Key, antidote_crdt_mvreg, <<"bucket">>},
+    Bound_object = {Key, antidote_crdt_register_mv, <<"bucket">>},
     {ok, Tx1} = antidotec_pb:start_transaction(Pid1, ignore, {}),
     ok = antidotec_pb:update_objects(Pid1, [{Bound_object, assign, <<"a">>}], Tx1),
     {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx1),
@@ -334,21 +334,21 @@ crdt_set_rw_test(_Config) ->
 crdt_gmap_test(_Config) ->
   Key = <<"pb_client_SUITE_crdt_map_aw_test">>,
   {ok, Pid1} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-  Bound_object = {Key, antidote_crdt_gmap, <<"bucket">>},
+  Bound_object = {Key, antidote_crdt_map_go, <<"bucket">>},
   {ok, Tx1} = antidotec_pb:start_transaction(Pid1, ignore, {}),
   ok = antidotec_pb:update_objects(Pid1, [
     {Bound_object, update, {{<<"a">>, antidote_crdt_integer}, {set, 42}}}], Tx1),
   ok = antidotec_pb:update_objects(Pid1, [
     {Bound_object, update, [
-      {{<<"b">>, antidote_crdt_lwwreg}, {assign, <<"X">>}},
-      {{<<"c">>, antidote_crdt_mvreg}, {assign, <<"Paul">>}},
-      {{<<"d">>, antidote_crdt_orset}, {add_all, [<<"Apple">>, <<"Banana">>]}},
+      {{<<"b">>, antidote_crdt_register_lww}, {assign, <<"X">>}},
+      {{<<"c">>, antidote_crdt_register_mv}, {assign, <<"Paul">>}},
+      {{<<"d">>, antidote_crdt_set_aw}, {add_all, [<<"Apple">>, <<"Banana">>]}},
       {{<<"e">>, antidote_crdt_set_rw}, {add_all, [<<"Apple">>, <<"Banana">>]}},
-      {{<<"f">>, antidote_crdt_counter}, {increment , 7}},
-      {{<<"g">>, antidote_crdt_gmap}, {update, [
+      {{<<"f">>, antidote_crdt_counter_pn}, {increment , 7}},
+      {{<<"g">>, antidote_crdt_map_go}, {update, [
         {{<<"x">>, antidote_crdt_integer}, {set, 17}}
       ]}},
-      {{<<"h">>, antidote_crdt_map_aw}, {update, [
+      {{<<"h">>, antidote_crdt_map_rr}, {update, [
         {{<<"x">>, antidote_crdt_integer}, {set, 15}}
       ]}}
     ]}], Tx1),
@@ -359,15 +359,15 @@ crdt_gmap_test(_Config) ->
   {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx3),
   ExpectedRes = {map, [
     {{<<"a">>, antidote_crdt_integer}, 42},
-    {{<<"b">>, antidote_crdt_lwwreg}, <<"X">>},
-    {{<<"c">>, antidote_crdt_mvreg}, [<<"Paul">>]},
-    {{<<"d">>, antidote_crdt_orset}, [<<"Apple">>, <<"Banana">>]},
+    {{<<"b">>, antidote_crdt_register_lww}, <<"X">>},
+    {{<<"c">>, antidote_crdt_register_mv}, [<<"Paul">>]},
+    {{<<"d">>, antidote_crdt_set_aw}, [<<"Apple">>, <<"Banana">>]},
     {{<<"e">>, antidote_crdt_set_rw}, [<<"Apple">>, <<"Banana">>]},
-    {{<<"f">>, antidote_crdt_counter}, 7},
-    {{<<"g">>, antidote_crdt_gmap}, [
+    {{<<"f">>, antidote_crdt_counter_pn}, 7},
+    {{<<"g">>, antidote_crdt_map_go}, [
       {{<<"x">>, antidote_crdt_integer}, 17}
     ]},
-    {{<<"h">>, antidote_crdt_map_aw}, [
+    {{<<"h">>, antidote_crdt_map_rr}, [
       {{<<"x">>, antidote_crdt_integer}, 15}
     ]}
   ]},
@@ -377,43 +377,43 @@ crdt_gmap_test(_Config) ->
 crdt_map_aw_test(_Config) ->
   Key = <<"pb_client_SUITE_crdt_map_aw_test">>,
   {ok, Pid1} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-  Bound_object = {Key, antidote_crdt_map_aw, <<"bucket">>},
+  Bound_object = {Key, antidote_crdt_map_rr, <<"bucket">>},
   {ok, Tx1} = antidotec_pb:start_transaction(Pid1, ignore, {}),
   ok = antidotec_pb:update_objects(Pid1, [
     {Bound_object, update, {{<<"a">>, antidote_crdt_integer}, {set, 42}}}], Tx1),
   ok = antidotec_pb:update_objects(Pid1, [
     {Bound_object, update, [
-      {{<<"b">>, antidote_crdt_lwwreg}, {assign, <<"X">>}},
-      {{<<"b1">>, antidote_crdt_lwwreg}, {assign, <<"X1">>}},
-      {{<<"b2">>, antidote_crdt_lwwreg}, {assign, <<"X2">>}},
-      {{<<"b3">>, antidote_crdt_lwwreg}, {assign, <<"X3">>}},
-      {{<<"b4">>, antidote_crdt_lwwreg}, {assign, <<"X4">>}},
-      {{<<"b5">>, antidote_crdt_lwwreg}, {assign, <<"X5">>}},
-      {{<<"c">>, antidote_crdt_mvreg}, {assign, <<"Paul">>}},
-      {{<<"d">>, antidote_crdt_orset}, {add_all, [<<"Apple">>, <<"Banana">>]}},
+      {{<<"b">>, antidote_crdt_register_lww}, {assign, <<"X">>}},
+      {{<<"b1">>, antidote_crdt_register_lww}, {assign, <<"X1">>}},
+      {{<<"b2">>, antidote_crdt_register_lww}, {assign, <<"X2">>}},
+      {{<<"b3">>, antidote_crdt_register_lww}, {assign, <<"X3">>}},
+      {{<<"b4">>, antidote_crdt_register_lww}, {assign, <<"X4">>}},
+      {{<<"b5">>, antidote_crdt_register_lww}, {assign, <<"X5">>}},
+      {{<<"c">>, antidote_crdt_register_mv}, {assign, <<"Paul">>}},
+      {{<<"d">>, antidote_crdt_set_aw}, {add_all, [<<"Apple">>, <<"Banana">>]}},
       {{<<"e">>, antidote_crdt_set_rw}, {add_all, [<<"Apple">>, <<"Banana">>]}},
-      {{<<"f">>, antidote_crdt_counter}, {increment , 7}},
-      {{<<"g">>, antidote_crdt_gmap}, {update, [
+      {{<<"f">>, antidote_crdt_counter_pn}, {increment , 7}},
+      {{<<"g">>, antidote_crdt_map_go}, {update, [
         {{<<"x">>, antidote_crdt_integer}, {set, 17}}
       ]}},
-      {{<<"h">>, antidote_crdt_map_aw}, {update, [
+      {{<<"h">>, antidote_crdt_map_rr}, {update, [
         {{<<"x">>, antidote_crdt_integer}, {set, 15}}
       ]}}
     ]}], Tx1),
   ok = antidotec_pb:update_objects(Pid1, [
-    {Bound_object, remove, {<<"b1">>, antidote_crdt_lwwreg}}], Tx1),
+    {Bound_object, remove, {<<"b1">>, antidote_crdt_register_lww}}], Tx1),
   ok = antidotec_pb:update_objects(Pid1,
     [{Bound_object, remove, [
-      {<<"b2">>, antidote_crdt_lwwreg},
-      {<<"b3">>, antidote_crdt_lwwreg}]}
+      {<<"b2">>, antidote_crdt_register_lww},
+      {<<"b3">>, antidote_crdt_register_lww}]}
     ], Tx1),
   ok = antidotec_pb:update_objects(Pid1,
     [{Bound_object, batch,
       {[ % updates
-        {{<<"i">>, antidote_crdt_lwwreg}, {assign, <<"X">>}}
+        {{<<"i">>, antidote_crdt_register_lww}, {assign, <<"X">>}}
       ], [ % removes
-        {<<"b4">>, antidote_crdt_lwwreg},
-        {<<"b5">>, antidote_crdt_lwwreg}
+        {<<"b4">>, antidote_crdt_register_lww},
+        {<<"b5">>, antidote_crdt_register_lww}
       ]}}
     ], Tx1),
   {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx1),
@@ -423,18 +423,18 @@ crdt_map_aw_test(_Config) ->
   {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx3),
   ExpectedRes = {map, [
     {{<<"a">>, antidote_crdt_integer}, 42},
-    {{<<"b">>, antidote_crdt_lwwreg}, <<"X">>},
-    {{<<"c">>, antidote_crdt_mvreg}, [<<"Paul">>]},
-    {{<<"d">>, antidote_crdt_orset}, [<<"Apple">>, <<"Banana">>]},
+    {{<<"b">>, antidote_crdt_register_lww}, <<"X">>},
+    {{<<"c">>, antidote_crdt_register_mv}, [<<"Paul">>]},
+    {{<<"d">>, antidote_crdt_set_aw}, [<<"Apple">>, <<"Banana">>]},
     {{<<"e">>, antidote_crdt_set_rw}, [<<"Apple">>, <<"Banana">>]},
-    {{<<"f">>, antidote_crdt_counter}, 7},
-    {{<<"g">>, antidote_crdt_gmap}, [
+    {{<<"f">>, antidote_crdt_counter_pn}, 7},
+    {{<<"g">>, antidote_crdt_map_go}, [
       {{<<"x">>, antidote_crdt_integer}, 17}
     ]},
-    {{<<"h">>, antidote_crdt_map_aw}, [
+    {{<<"h">>, antidote_crdt_map_rr}, [
       {{<<"x">>, antidote_crdt_integer}, 15}
     ]},
-    {{<<"i">>, antidote_crdt_lwwreg}, <<"X">>}
+    {{<<"i">>, antidote_crdt_register_lww}, <<"X">>}
   ]},
   ?assertEqual(ExpectedRes, Val),
   _Disconnected = antidotec_pb_socket:stop(Pid1).
@@ -449,18 +449,18 @@ crdt_map_rr_test(_Config) ->
     {Bound_object, update, {{<<"a">>, antidote_crdt_integer}, {set, 42}}}], Tx1),
   ok = antidotec_pb:update_objects(Pid1, [
     {Bound_object, update, [
-      {{<<"b">>, antidote_crdt_mvreg}, {assign, <<"X">>}},
-      {{<<"b1">>, antidote_crdt_mvreg}, {assign, <<"X1">>}},
-      {{<<"b2">>, antidote_crdt_mvreg}, {assign, <<"X2">>}},
-      {{<<"b3">>, antidote_crdt_mvreg}, {assign, <<"X3">>}},
-      {{<<"b4">>, antidote_crdt_mvreg}, {assign, <<"X4">>}},
-      {{<<"b5">>, antidote_crdt_mvreg}, {assign, <<"X5">>}},
-      {{<<"c">>, antidote_crdt_mvreg}, {assign, <<"Paul">>}},
-      {{<<"d">>, antidote_crdt_orset}, {add_all, [<<"Apple">>, <<"Banana">>]}},
-      {{<<"e">>, antidote_crdt_orset}, {add_all, [<<"Apple">>, <<"Banana">>]}},
+      {{<<"b">>, antidote_crdt_register_mv}, {assign, <<"X">>}},
+      {{<<"b1">>, antidote_crdt_register_mv}, {assign, <<"X1">>}},
+      {{<<"b2">>, antidote_crdt_register_mv}, {assign, <<"X2">>}},
+      {{<<"b3">>, antidote_crdt_register_mv}, {assign, <<"X3">>}},
+      {{<<"b4">>, antidote_crdt_register_mv}, {assign, <<"X4">>}},
+      {{<<"b5">>, antidote_crdt_register_mv}, {assign, <<"X5">>}},
+      {{<<"c">>, antidote_crdt_register_mv}, {assign, <<"Paul">>}},
+      {{<<"d">>, antidote_crdt_set_aw}, {add_all, [<<"Apple">>, <<"Banana">>]}},
+      {{<<"e">>, antidote_crdt_set_aw}, {add_all, [<<"Apple">>, <<"Banana">>]}},
       {{<<"f">>, antidote_crdt_fat_counter}, {increment , 7}},
       {{<<"g">>, antidote_crdt_map_rr}, {update, [
-        {{<<"q">>, antidote_crdt_mvreg}, {assign, <<"Hello">>}},
+        {{<<"q">>, antidote_crdt_register_mv}, {assign, <<"Hello">>}},
         {{<<"x">>, antidote_crdt_fat_counter}, {increment, 17}}
       ]}},
       {{<<"h">>, antidote_crdt_map_rr}, {update, [
@@ -468,19 +468,19 @@ crdt_map_rr_test(_Config) ->
       ]}}
     ]}], Tx1),
   ok = antidotec_pb:update_objects(Pid1, [
-    {Bound_object, remove, {<<"b1">>, antidote_crdt_mvreg}}], Tx1),
+    {Bound_object, remove, {<<"b1">>, antidote_crdt_register_mv}}], Tx1),
   ok = antidotec_pb:update_objects(Pid1,
     [{Bound_object, remove, [
-      {<<"b2">>, antidote_crdt_mvreg},
-      {<<"b3">>, antidote_crdt_mvreg}]}
+      {<<"b2">>, antidote_crdt_register_mv},
+      {<<"b3">>, antidote_crdt_register_mv}]}
     ], Tx1),
   ok = antidotec_pb:update_objects(Pid1,
     [{Bound_object, batch,
       {[ % updates
-        {{<<"i">>, antidote_crdt_mvreg}, {assign, <<"X">>}}
+        {{<<"i">>, antidote_crdt_register_mv}, {assign, <<"X">>}}
       ], [ % removes
-        {<<"b4">>, antidote_crdt_mvreg},
-        {<<"b5">>, antidote_crdt_mvreg}
+        {<<"b4">>, antidote_crdt_register_mv},
+        {<<"b5">>, antidote_crdt_register_mv}
       ]}}
     ], Tx1),
   ok = antidotec_pb:update_objects(Pid1, [
@@ -492,15 +492,15 @@ crdt_map_rr_test(_Config) ->
   {ok, _} = antidotec_pb:commit_transaction(Pid1, Tx3),
   ExpectedRes = {map, [
     {{<<"a">>, antidote_crdt_integer}, 42},
-    {{<<"b">>, antidote_crdt_mvreg}, [<<"X">>]},
-    {{<<"c">>, antidote_crdt_mvreg}, [<<"Paul">>]},
-    {{<<"d">>, antidote_crdt_orset}, [<<"Apple">>, <<"Banana">>]},
-    {{<<"e">>, antidote_crdt_orset}, [<<"Apple">>, <<"Banana">>]},
+    {{<<"b">>, antidote_crdt_register_mv}, [<<"X">>]},
+    {{<<"c">>, antidote_crdt_register_mv}, [<<"Paul">>]},
+    {{<<"d">>, antidote_crdt_set_aw}, [<<"Apple">>, <<"Banana">>]},
+    {{<<"e">>, antidote_crdt_set_aw}, [<<"Apple">>, <<"Banana">>]},
     {{<<"f">>, antidote_crdt_fat_counter}, 7},
     {{<<"h">>, antidote_crdt_map_rr}, [
       {{<<"x">>, antidote_crdt_fat_counter}, 15}
     ]},
-    {{<<"i">>, antidote_crdt_mvreg}, [<<"X">>]}
+    {{<<"i">>, antidote_crdt_register_mv}, [<<"X">>]}
   ]},
   ?assertEqual(ExpectedRes, Val),
   _Disconnected = antidotec_pb_socket:stop(Pid1).
@@ -531,7 +531,7 @@ crdt_flag_test(_Config, FlagCrdt) ->
 static_transaction_test(_Config) ->
     Key = <<"pb_client_SUITE_static_transaction_test">>,
     {ok, Pid} = antidotec_pb_socket:start(?ADDRESS, ?PORT),
-    Bound_object = {Key, antidote_crdt_orset, <<"bucket">>},
+    Bound_object = {Key, antidote_crdt_set_aw, <<"bucket">>},
     Set = antidotec_set:new(),
     Set1 = antidotec_set:add(<<"a">>, Set),
     Set2 = antidotec_set:add(<<"b">>, Set1),

--- a/test/release_test.escript
+++ b/test/release_test.escript
@@ -23,7 +23,7 @@ main(_) ->
 test_transaction(Tries) ->
     {ok, Pid} = try_connect(10),
     Key = <<"release_test_key">>,
-    Bound_object = {Key, antidote_crdt_counter, <<"release_test_key_bucket">>},
+    Bound_object = {Key, antidote_crdt_counter_pn, <<"release_test_key_bucket">>},
     io:format("Starting Test transaction~n"),
     case antidotec_pb:start_transaction(Pid, ignore, {}) of
         {error, Reason} when Tries > 0 ->


### PR DESCRIPTION
Updates the CRDT library with the renamed/removed CRDT module names (see https://github.com/SyncFree/antidote_crdt/pull/21)

Renamed:
 - antidote_crdt_bcounter → antidote_crdt_counter_b
 - antidote_crdt_fat_counter → antidote_crdt_counter_fat
 - antidote_crdt_counter → antidote_crdt_counter_pn
 - antidote_crdt_gmap → antidote_crdt_map_go
 - antidote_crdt_lwwreg → antidote_crdt_register_lww
 - antidote_crdt_mvreg → antidote_crdt_register_mv
 - antidote_crdt_orset → antidote_crdt_set_aw
 - antidote_crdt_gset → antidote_crdt_set_go

Removed:

 - antidote_crdt_integer
 - antidote_crdt_map_aw
 - antidote_crdt_map
 - antidote_crdt_rga

Backwards-compatibility: The protocol buffer interface is the same for renamed types, so clients that don't use the integer or map_aw still work as before. Clients which used the removed types have to migrate from antidote_crdt_map_aw to antidote_crdt_map_rr and from antidote_crdt_integer to antidote_crdt_counter_pn and/or antidote_crdt_register_mv.
