### PR TITLE
Resolve public IP for InterDC descriptors

### DIFF
--- a/src/inter_dc_pub.erl
+++ b/src/inter_dc_pub.erl
@@ -49,17 +49,32 @@
 
 -spec get_address() -> socket_address().
 get_address() ->
-  %% TODO check if we do not return a link-local address
-  {ok, List} = inet:getif(),
-  {Ip, _, _} = hd(List),
+  %% first try resolving our hostname according to the node name
+  [_, Hostname] = string:tokens(atom_to_list(erlang:node()), "@"),
+  Ip = case inet:getaddr(Hostname, inet) of
+    {ok, HostIp} -> HostIp;
+    {error, _} ->
+      %% cannot resolve hostname locally, fall back to interface ip
+      %% TODO check if we do not return a link-local address
+      {ok, List} = inet:getif(),
+      {IIp, _, _} = hd(List),
+      IIp
+  end,
   Port = application:get_env(antidote, pubsub_port, ?DEFAULT_PUBSUB_PORT),
   {Ip, Port}.
 
 -spec get_address_list() -> [socket_address()].
 get_address_list() ->
     {ok, List} = inet:getif(),
+    List1 = [Ip1 || {Ip1, _, _} <- List],
+    %% get host name from node name
+    [_, Hostname] = string:tokens(atom_to_list(erlang:node()), "@"),
+    IpList = case inet:getaddr(Hostname, inet) of
+      {ok, HostIp} -> [HostIp|List1];
+      {error, _} -> List1
+    end,
     Port = application:get_env(antidote, pubsub_port, ?DEFAULT_PUBSUB_PORT),
-    [{Ip1, Port} || {Ip1, _, _} <- List, Ip1 /= {127, 0, 0, 1}].
+    [{Ip1, Port} || Ip1 <- IpList, Ip1 /= {127, 0, 0, 1}].
 
 -spec broadcast(#interdc_txn{}) -> ok.
 broadcast(Txn) ->

--- a/src/inter_dc_query_receive_socket.erl
+++ b/src/inter_dc_query_receive_socket.erl
@@ -53,17 +53,32 @@
 %% Fetch the local address of a log_reader socket.
 -spec get_address() -> socket_address().
 get_address() ->
-  {ok, List} = inet:getif(),
-  {Ip, _, _} = hd(List),
+  %% first try resolving our hostname according to the node name
+  [_, Hostname] = string:tokens(atom_to_list(erlang:node()), "@"),
+  Ip = case inet:getaddr(Hostname, inet) of
+    {ok, HostIp} -> HostIp;
+    {error, _} ->
+      %% cannot resolve hostname locally, fall back to interface ip
+      %% TODO check if we do not return a link-local address
+      {ok, List} = inet:getif(),
+      {IIp, _, _} = hd(List),
+      IIp
+  end,
   Port = application:get_env(antidote, logreader_port, ?DEFAULT_LOGREADER_PORT),
   {Ip, Port}.
 
 -spec get_address_list() -> {[partition_id()], [socket_address()]}.
 get_address_list() ->
     PartitionList = dc_utilities:get_my_partitions(),
-    {ok, List} = inet:getif(),
+    List1 = [Ip1 || {Ip1, _, _} <- List],
+    %% get host name from node name
+    [_, Hostname] = string:tokens(atom_to_list(erlang:node()), "@"),
+    IpList = case inet:getaddr(Hostname, inet) of
+      {ok, HostIp} -> [HostIp|List1];
+      {error, _} -> List1
+    end,
     Port = application:get_env(antidote, logreader_port, ?DEFAULT_LOGREADER_PORT),
-    AddressList = [{Ip1, Port} || {Ip1, _, _} <- List, Ip1 /= {127, 0, 0, 1}],
+    AddressList = [{Ip1, Port} || Ip1 <- IpList, Ip1 /= {127, 0, 0, 1}],
     {PartitionList, AddressList}.
 
 -spec send_response(binary(), #inter_dc_query_state{}) -> ok.

--- a/src/inter_dc_query_receive_socket.erl
+++ b/src/inter_dc_query_receive_socket.erl
@@ -70,6 +70,7 @@ get_address() ->
 -spec get_address_list() -> {[partition_id()], [socket_address()]}.
 get_address_list() ->
     PartitionList = dc_utilities:get_my_partitions(),
+    {ok, List} = inet:getif(),
     List1 = [Ip1 || {Ip1, _, _} <- List],
     %% get host name from node name
     [_, Hostname] = string:tokens(atom_to_list(erlang:node()), "@"),


### PR DESCRIPTION
In the current version, the IP addresses used in the InterDC descriptors are only resolved using the IPs of the local network devices. In many setups this is not good enough. If an Antidote node runs behind a firewall with port forwarding then the local IP is not identical with the public IP. The same is true for Docker setups in which the ports of the Docker container are forwarded to the machine running Docker (see issue #336).

This pull request changes the code that computes the IPs used in the descriptor to use the address mentioned in the node name. The node name has to be configured correctly for distributed Erlang to work. Distributed Erlang is needed to setup the InterDC connection. The host mentioned in the node name (e.g. antidote@myhost.example.com) is resolved to an IP address (in this case the IP of myhost.example.com) and added as another endpoint for publishers and logreaders. Sending this descriptor to remote nodes allows to connect these nodes using InterDC communication to the public endpoint (e.g. the firewall host).

This should allow to fix firewall setup in which the machine running Antidote is not publicly visible by forwarding the ports to some publicly accessible host and setting the node name to mention the hostname/IP of the host.