### PR TITLE
Optimized and Fixed Tests

### DIFF
--- a/bin/env
+++ b/bin/env
@@ -98,17 +98,20 @@ fi
 
 export RELX_REPLACE_OS_VARS=true
 
-echo "MESOS_TASK_ID: ${MESOS_TASK_ID}"
-echo "PORT0: ${PORT0}"
-echo "PORT1: ${PORT1}"
-echo "PORT2: ${PORT2}"
-echo "PORT3: ${PORT3}"
-echo "PORT4: ${PORT4}"
-echo "PORT5: ${PORT5}"
+# Print task id and ports only if assigned
+[[ -z "${MESOS_TASK_ID}" ]] || echo "MESOS_TASK_ID: ${MESOS_TASK_ID}"
+[[ -z "${PORT0}" ]] || echo "PORT0: ${PORT0}"
+[[ -z "${PORT1}" ]] || echo "PORT0: ${PORT1}"
+[[ -z "${PORT2}" ]] || echo "PORT0: ${PORT2}"
+[[ -z "${PORT3}" ]] || echo "PORT0: ${PORT3}"
+[[ -z "${PORT4}" ]] || echo "PORT0: ${PORT4}"
+[[ -z "${PORT5}" ]] || echo "PORT0: ${PORT5}"
+
 echo "NODE_NAME: ${NODE_NAME}"
 echo "COOKIE: ${COOKIE}"
 echo "IP: ${IP}"
 echo "HOSTNAME: ${HOSTNAME}"
 
+# Execute antidote release script
 RELNAME="`dirname \"$0\"`"/antidote
 exec ${RELNAME} "$@"

--- a/test/antidote_SUITE.erl
+++ b/test/antidote_SUITE.erl
@@ -97,7 +97,7 @@ dummy_test(Config) ->
         end,
     Delay = 100,
     Retry = 360000 div Delay, %wait for max 1 min
-    ok = test_utils:wait_until_result(F, 3, Retry, Delay),
+    ok = time_utils:wait_until_result(F, 3, Retry, Delay),
 
     ok.
 
@@ -238,5 +238,5 @@ random_test(Config) ->
         end,
     Delay = 1000,
     Retry = 360000 div Delay, %wait for max 1 min
-    ok = test_utils:wait_until_result(G, NumWrites, Retry, Delay),
+    ok = time_utils:wait_until_result(G, NumWrites, Retry, Delay),
     pass.

--- a/test/antidote_SUITE.erl
+++ b/test/antidote_SUITE.erl
@@ -17,14 +17,6 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-%% @doc log_test: Test that perform NumWrites increments to the key:key1.
-%%      Each increment is sent to a random node of the cluster.
-%%      Test normal behavior of the logging layer
-%%      Performs a read to the first node of the cluster to check whether all the
-%%      increment operations where successfully applied.
-%%  Variables:  N:  Number of nodes
-%%              Nodes: List of the nodes that belong to the built cluster
-%%
 
 -module(antidote_SUITE).
 
@@ -50,21 +42,23 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
+-define(BUCKET, antidote_bucket).
 
 init_per_suite(Config) ->
+    ct:print("Starting test suite ~p", [?MODULE]),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = hd(Clusters),
     [{nodes, Nodes}|Config].
 
 end_per_suite(Config) ->
-                                                %application:stop(lager),
     Config.
 
-init_per_testcase(_Case, Config) ->
+init_per_testcase(_Name, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() ->
@@ -80,7 +74,6 @@ all() ->
 
 dummy_test(Config) ->
     [Node1, Node2 | _Nodes] = proplists:get_value(nodes, Config),
-    ct:print("Test on ~p!", [Node1]),
     Key = antidote_key,
     Type = antidote_crdt_counter_pn,
     Bucket = antidote_bucket,
@@ -217,14 +210,14 @@ random_test(Config) ->
     Nodes = proplists:get_value(nodes, Config),
     N = length(Nodes),
 
-                                                % Distribute the updates randomly over all DCs
+    % Distribute the updates randomly over all DCs
     NumWrites = 100,
-    ListIds = [rand_compat:uniform(N) || _ <- lists:seq(1, NumWrites)], % TODO avoid nondeterminism in tests
+    ListIds = [rand_compat:uniform(N) || _ <- lists:seq(1, NumWrites)], % TODO avoid non-determinism in tests
 
     Obj = {log_test_key1, antidote_crdt_counter_pn, antidote_bucket},
     F = fun(Elem) ->
                 Node = lists:nth(Elem, Nodes),
-                ct:print("Inc at node: ~p", [Node]),
+                lager:info("Increment at node: ~p", [Node]),
                 {ok, _} = rpc:call(Node, antidote, update_objects,
                                   [ignore, [], [{Obj, increment, 1}]])
         end,

--- a/test/append_SUITE.erl
+++ b/test/append_SUITE.erl
@@ -17,14 +17,6 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-%% @doc log_test: Test that perform NumWrites increments to the key:key1.
-%%      Each increment is sent to a random node of the cluster.
-%%      Test normal behavior of the logging layer
-%%      Performs a read to the first node of the cluster to check whether all the
-%%      increment operations where successfully applied.
-%%  Variables:  N:  Number of nodes
-%%              Nodes: List of the nodes that belong to the built cluster
-%%
 
 -module(append_SUITE).
 
@@ -63,7 +55,8 @@ end_per_suite(Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() ->
@@ -75,15 +68,15 @@ all() ->
 append_test(Config) ->
     Nodes = proplists:get_value(nodes, Config),
     Node = hd(Nodes),
-    ct:print("Starting write operation 1"),
+    lager:info("Starting write operation 1"),
     increment_counter(Node, append_key1),
 
-    ct:print("Starting write operation 2"),
+    lager:info("Starting write operation 2"),
     increment_counter(Node, append_key2),
 
-    ct:print("Starting read operation 1"),
+    lager:info("Starting read operation 1"),
     read_counter(Node, append_key1, 1),
-    ct:print("Starting read operation 2"),
+    lager:info("Starting read operation 2"),
     read_counter(Node, append_key2, 1).
 
 append_failure_test(Config) ->
@@ -93,10 +86,10 @@ append_failure_test(Config) ->
 
     %% Identify preference list for a given key.
     Preflist = rpc:call(N, log_utilities, get_preflist_from_key, [Key]),
-    ct:print("Preference list: ~p", [Preflist]),
+    lager:info("Preference list: ~p", [Preflist]),
 
     NodeList = [Node || {_Index, Node} <- Preflist],
-    ct:print("Responsible nodes for key: ~p", [NodeList]),
+    lager:info("Responsible nodes for key: ~p", [NodeList]),
 
     {A, _} = lists:split(1, NodeList),
     First = hd(A),

--- a/test/bcountermgr_SUITE.erl
+++ b/test/bcountermgr_SUITE.erl
@@ -53,8 +53,8 @@ init_per_suite(Config) ->
 
     %Ensure that write operations are certified
     test_utils:pmap(fun(Node) ->
-        rpc:call(Node, application, set_env,
-        [antidote, txn_cert, true]) end, Nodes),
+        rpc:call(Node, application, set_env, [antidote, txn_cert, true])
+                    end, Nodes),
 
     %Check that indeed transactions certification is turned on
     {ok, true} = rpc:call(hd(hd(Clusters)), application, get_env, [antidote, txn_cert]),

--- a/test/bcountermgr_SUITE.erl
+++ b/test/bcountermgr_SUITE.erl
@@ -42,11 +42,12 @@
 -include_lib("kernel/include/inet.hrl").
 
 -define(TYPE, antidote_crdt_counter_b).
--define(BUCKET, bcounter_bucket).
--define(RETRY_COUNT, 5).
+-define(BUCKET, bcountermgr_bucket).
+-define(RETRY_COUNT, 10).
 
 
 init_per_suite(Config) ->
+    ct:print("Starting test suite ~p", [?MODULE]),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = lists:flatten(Clusters),
@@ -69,7 +70,8 @@ end_per_suite(Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() -> [
@@ -159,7 +161,7 @@ execute_op(Node, Op, Key, Amount, Actor) ->
 
 %%Auxiliary functions.
 execute_op_success(Node, Op, Key, Amount, Actor, Try) ->
-    ct:print("Execute OP ~p", [Key]),
+    lager:info("Execute OP ~p", [Key]),
     Result = rpc:call(Node, antidote, update_objects,
                       [ignore, [],
                        [{{Key, ?TYPE, ?BUCKET}, Op, {Amount, Actor} }]
@@ -174,7 +176,7 @@ execute_op_success(Node, Op, Key, Amount, Actor, Try) ->
     end.
 
 read_si(Node, Key, CommitTime) ->
-    ct:print("Read si  ~p", [Key]),
+    lager:info("Read si ~p", [Key]),
     rpc:call(Node, antidote, read_objects, [CommitTime, [], [{Key, ?TYPE, ?BUCKET}]]).
 
 check_read(Node, Key, Expected, CommitTime) ->

--- a/test/commit_hooks_SUITE.erl
+++ b/test/commit_hooks_SUITE.erl
@@ -41,11 +41,9 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
 
--define(ADDRESS, "localhost").
-
--define(PORT, 10017).
 
 init_per_suite(Config) ->
+    ct:print("Starting test suite ~p", [?MODULE]),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = hd(Clusters),
@@ -57,7 +55,8 @@ end_per_suite(Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() -> [register_hook_test,

--- a/test/gr_SUITE.erl
+++ b/test/gr_SUITE.erl
@@ -41,7 +41,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
 
+-define(BUCKET, gr_bucket).
+
 init_per_suite(Config) ->
+    ct:print("Starting test suite ~p", [?MODULE]),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = lists:flatten(Clusters),
@@ -67,7 +70,8 @@ end_per_suite(Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() -> [read_write_test,
@@ -75,7 +79,6 @@ all() -> [read_write_test,
           replication_test].
 
 read_write_test(Config) ->
-    lager:info("Single read write test"),
     Nodes = proplists:get_value(nodes, Config),
     Node = hd(Nodes),
     Bound_object = {gr_rw_key, antidote_crdt_counter_pn, bucket},
@@ -85,7 +88,6 @@ read_write_test(Config) ->
     ?assertMatch([1], Res).
 
 read_multiple_test(Config) ->
-    lager:info("Snapshot read"),
     Nodes = proplists:get_value(nodes, Config),
     Node = hd(Nodes),
     O1 = {gr_read_mult_key1, antidote_crdt_counter_pn, bucket},
@@ -96,7 +98,6 @@ read_multiple_test(Config) ->
     ?assertMatch([1, 1], Res).
 
 replication_test(Config) ->
-    lager:info("Replication Test"),
     [Node1, Node2 | _] = proplists:get_value(nodes, Config),
 
     O1 = {gr_repl_key1, antidote_crdt_counter_pn, bucket},

--- a/test/inter_dc_repl_SUITE.erl
+++ b/test/inter_dc_repl_SUITE.erl
@@ -41,9 +41,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
 
--define(BUCKET, "inter_dc_repl").
+-define(BUCKET, inter_dc_repl_bucket).
 
 init_per_suite(Config) ->
+    ct:print("Starting test suite ~p", [?MODULE]),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = lists:flatten(Clusters),
@@ -64,7 +65,8 @@ end_per_suite(Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() -> [simple_replication_test,
@@ -84,7 +86,6 @@ simple_replication_test(Config) ->
     check_read_key(Node1, Key, Type, 3, CommitTime, static),
 
     check_read_key(Node2, Key, Type, 3, CommitTime, static),
-    lager:info("Simple replication test passed!"),
     pass.
 
 multiple_keys_test(Config) ->
@@ -100,7 +101,6 @@ multiple_keys_test(Config) ->
 
     multiple_reads(Node1, Key, Type, 1, 10, 10, CommitTime),
     multiple_reads(Node2, Key, Type, 1, 10, 10, CommitTime),
-    lager:info("Multiple key read-write test passed!"),
     pass.
 
 multiple_writes(Node, PreKey, _Type, Start, End, _Actor)->
@@ -137,7 +137,6 @@ causality_test(Config) ->
     {ok, CommitTime3} = update_sets(Node2, [Key], [{remove, first}], CommitTime2),
     %% Read result
     check_read_key(Node2, Key, Type, [second], CommitTime3, static),
-    lager:info("Causality test passed!"),
     pass.
 
 %% This tests checks reads are atomic when replicated to other DCs

--- a/test/inter_dc_repl_SUITE.erl
+++ b/test/inter_dc_repl_SUITE.erl
@@ -163,7 +163,7 @@ atomicity_test(Config) ->
                        %% Read until all writes are read and make sure reads see atomic snapshots
                        Delay = 100,
                        Retry = 360000 div Delay, %wait for max 1 min
-                       ok = test_utils:wait_until_result(fun() ->
+                       ok = time_utils:wait_until_result(fun() ->
                                                       atomic_read_txn(Node2, Key1, Key2, Key3, Type)
                                                     end,
                                                     10,

--- a/test/log_recovery_SUITE.erl
+++ b/test/log_recovery_SUITE.erl
@@ -38,7 +38,6 @@
 -include_lib("kernel/include/inet.hrl").
 
 init_per_suite(Config) ->
-    lager_common_test_backend:bounce(debug),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = hd(Clusters),
@@ -83,10 +82,10 @@ read_pncounter_log_recovery_test(Config) ->
 
             ?assertEqual(15, ReadResult2),
 
-            lager:info("Killing and restarting the nodes"),
+            ct:print("Killing and restarting the nodes"),
             %% Shut down the nodes
             Nodes = test_utils:kill_and_restart_nodes(Nodes, Config),
-            lager:info("Vnodes are started up"),
+            ct:print("Vnodes are started up"),
             lager:info("Nodes: ~p", [Nodes]),
 
             %% Read the value again

--- a/test/multiple_dcs_SUITE.erl
+++ b/test/multiple_dcs_SUITE.erl
@@ -41,9 +41,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
 
--define(BUCKET, "multiple_dcs").
+-define(BUCKET, multiple_dcs_bucket).
 
 init_per_suite(Config) ->
+    ct:print("Starting test suite ~p", [?MODULE]),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = lists:flatten(Clusters),
@@ -64,7 +65,8 @@ end_per_suite(Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() ->

--- a/test/multiple_dcs_node_failure_SUITE.erl
+++ b/test/multiple_dcs_node_failure_SUITE.erl
@@ -146,7 +146,7 @@ multiple_cluster_failure_test(Config) ->
             {ok, CommitTime} = update_counters(Node1, [Key], [1], ignore, static),
             check_read_key(Node1, Key, Type, 3, CommitTime, static),
 
-            %% Kill and restart a node and be sure everyhing works
+            %% Kill and restart a node and be sure everything works
             ct:print("Killing and restarting node ~w", [Node1]),
             [Node1] = test_utils:kill_and_restart_nodes([Node1], Config),
 
@@ -191,18 +191,18 @@ update_during_cluster_failure_test(Config) ->
             lager:info("Done append in Node1"),
 
             %% Kill a node
-            ct:print("Killing node ~w", [Node1]),
+            lager:info("Killing node ~w", [Node1]),
             [Node1] = test_utils:brutal_kill_nodes([Node1]),
 
             %% Be sure the other DC works while the node is down
             {ok, CommitTime3a} = update_counters(Node2, [Key], [1], ignore, static),
 
             %% Start the node back up and be sure everything works
-            ct:print("Restarting node ~w", [Node1]),
+            lager:info("Restarting node ~w", [Node1]),
             [Node1] = test_utils:restart_nodes([Node1], Config),
 
             %% Take the max of the commit times to be sure
-            %% to read all updateds
+            %% to read all updates
             Time = dict:merge(fun(_K, T1, T2) ->
                 max(T1, T2)
             end, CommitTime, CommitTime3a),

--- a/test/object_log_state_SUITE.erl
+++ b/test/object_log_state_SUITE.erl
@@ -41,7 +41,7 @@
 
 
 init_per_suite(Config) ->
-    lager_common_test_backend:bounce(debug),
+    ct:print("Starting test suite ~p", [?MODULE]),
     test_utils:at_init_testsuite(),
     Clusters = test_utils:set_up_clusters_common(Config),
     Nodes = hd(Clusters),
@@ -53,7 +53,8 @@ end_per_suite(Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(_, _) ->
+end_per_testcase(Name, _) ->
+    ct:print("[ OK ] ~p", [Name]),
     ok.
 
 all() -> [object_log_state_test].
@@ -86,9 +87,8 @@ object_log_state_test(Config) ->
     {ok, [LogOps]} = rpc:call(FirstNode,
                   antidote, get_log_operations, [[{BoundObject, CommitTime}]]),
 
-    ?assertEqual(ok, check_orset_ops(lists:seq(16, 30), LogOps, {Key, Bucket})),
+    ?assertEqual(ok, check_orset_ops(lists:seq(16, 30), LogOps, {Key, Bucket})).
 
-    lager:info("object_log_state_test_test finished").
 
 check_orset_ops([], [], _KeyBucket) ->
     ok;

--- a/test/release_test.sh
+++ b/test/release_test.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
-# This builds a release, starts it and tries to do simple transaction
-
+# This builds a release, starts it and tries to do simple transaction; exits immediately upon error
 set -e
 
+# cd to root project directory
 SCRIPTDIR=`dirname $0`
-pushd "$SCRIPTDIR/.." > /dev/null
-ROOT=`pwd -P`
-popd > /dev/null
-
-
-cd $ROOT
+cd "$SCRIPTDIR/.."
 
 # Start Antidote
 ./_build/default/rel/antidote/bin/env start
+
+# Wait for ports to be available for tcp connections
+sleep 1
 
 # Execute test transaction
 ./test/release_test.escript

--- a/test/riak_utils.erl
+++ b/test/riak_utils.erl
@@ -25,11 +25,11 @@
 -compile({parse_transform, lager_transform}).
 
 -export([
-    is_ring_ready/1, %
-    wait_until_ring_converged/1, %
-    wait_until_no_pending_changes/1, %
-    maybe_wait_for_changes/1, %
-    owners_according_to/1 %
+    is_ring_ready/1,
+    wait_until_ring_converged/1,
+    wait_until_no_pending_changes/1,
+    maybe_wait_for_changes/1,
+    owners_according_to/1
 ]).
 
 
@@ -51,7 +51,7 @@ wait_until_ring_converged(Nodes) ->
     ok.
 
 
-%% @doc Given a list of nodes-spec is_ring_ready([node()]) -> ok., wait until all nodes believe there are no
+%% @doc Given a list of nodes, wait until all nodes believe there are no
 %% on-going or pending ownership transfers.
 -spec wait_until_no_pending_changes([node()]) -> ok | fail.
 wait_until_no_pending_changes(Nodes) ->
@@ -78,13 +78,9 @@ maybe_wait_for_changes(Node) ->
 owners_according_to(Node) ->
     case rpc:call(Node, riak_core_ring_manager, get_raw_ring, []) of
         {ok, Ring} ->
-            lager:debug("Ring ~p", [Ring]),
             Owners = [Owner || {_Idx, Owner} <- riak_core_ring:all_owners(Ring)],
-            lager:debug("Owners ~p", [lists:usort(Owners)]),
             lists:usort(Owners);
         {badrpc, _} = BadRpc ->
-            lager:info("Badrpc"),
+            ct:print("Bad rpc call to riak core: ~p", [BadRpc]),
             BadRpc
     end.
-
-

--- a/test/riak_utils.erl
+++ b/test/riak_utils.erl
@@ -1,0 +1,90 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Helium Systems, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_utils).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile({parse_transform, lager_transform}).
+
+-export([
+    is_ring_ready/1, %
+    wait_until_ring_converged/1, %
+    wait_until_no_pending_changes/1, %
+    maybe_wait_for_changes/1, %
+    owners_according_to/1 %
+]).
+
+
+%% @doc Calls the riak core ring manager to check if the ring of the given node is ready
+-spec is_ring_ready(node()) -> boolean().
+is_ring_ready(Node) ->
+    case rpc:call(Node, riak_core_ring_manager, get_raw_ring, []) of
+        {ok, Ring} -> riak_core_ring:ring_ready(Ring);
+        _ -> false
+    end.
+
+
+%% @doc Given a list of nodes, wait until all nodes believe the ring has
+%%      converged (ie. `riak_core_ring:is_ready' returns `true').
+-spec wait_until_ring_converged([node()]) -> ok.
+wait_until_ring_converged(Nodes) ->
+    lager:info("Wait until ring converged on ~p", [Nodes]),
+    [?assertEqual(ok, time_utils:wait_until(Node, fun is_ring_ready/1)) || Node <- Nodes],
+    ok.
+
+
+%% @doc Given a list of nodes-spec is_ring_ready([node()]) -> ok., wait until all nodes believe there are no
+%% on-going or pending ownership transfers.
+-spec wait_until_no_pending_changes([node()]) -> ok | fail.
+wait_until_no_pending_changes(Nodes) ->
+    lager:info("Wait until no pending changes on ~p", [Nodes]),
+    F = fun() ->
+        rpc:multicall(Nodes, riak_core_vnode_manager, force_handoffs, []),
+        {Rings, BadNodes} = rpc:multicall(Nodes, riak_core_ring_manager, get_raw_ring, []),
+        Changes = [ riak_core_ring:pending_changes(Ring) =:= [] || {ok, Ring} <- Rings ],
+        BadNodes =:= [] andalso length(Changes) =:= length(Nodes) andalso lists:all(fun(T) -> T end, Changes)
+        end,
+    ?assertEqual(ok, time_utils:wait_until(F)),
+    ok.
+
+
+%% @doc TODO
+-spec maybe_wait_for_changes(node()) -> ok | fail.
+maybe_wait_for_changes(Node) ->
+    wait_until_no_pending_changes([Node]).
+
+
+%% @doc Return a list of nodes that own partitions according to the ring
+%%      retrieved from the specified node.
+-spec owners_according_to(node()) -> [node()] | {badrpc, any()}.
+owners_according_to(Node) ->
+    case rpc:call(Node, riak_core_ring_manager, get_raw_ring, []) of
+        {ok, Ring} ->
+            lager:debug("Ring ~p", [Ring]),
+            Owners = [Owner || {_Idx, Owner} <- riak_core_ring:all_owners(Ring)],
+            lager:debug("Owners ~p", [lists:usort(Owners)]),
+            lists:usort(Owners);
+        {badrpc, _} = BadRpc ->
+            lager:info("Badrpc"),
+            BadRpc
+    end.
+
+

--- a/test/time_utils.erl
+++ b/test/time_utils.erl
@@ -1,0 +1,156 @@
+%%%-------------------------------------------------------------------
+%%% @author schimpf
+%%% @copyright (C) 2018, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 23. May 2018 16:17
+%%%-------------------------------------------------------------------
+-module(time_utils).
+-author("schimpf").
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% API
+-export([
+    wait_until/1,
+    wait_until/2,
+    wait_until/3,
+    wait_until_result/4,
+    wait_until_registered/2,
+    wait_until_offline/1,
+    wait_until_disconnected/2,
+    wait_until_connected/2,
+    wait_until_nodes_agree_about_ownership/1,
+    wait_until_owners_according_to/2
+]).
+
+
+%% @doc Convenience wrapper for wait_until for the myriad functions that
+%% take a node as single argument.
+-spec wait_until(node(), fun()) -> true | {fail, any()}.
+wait_until(Node, Fun) when is_atom(Node), is_function(Fun) ->
+    wait_until(fun() -> Fun(Node) end).
+
+
+%% @doc Utility function used to construct test predicates. Retries the
+%%      function 'Fun' until it returns 'true', or until the maximum
+%%      number of retries is reached. Returns true or the failure reason.
+-spec wait_until(fun()) -> true | {fail, any()}.
+wait_until(Fun) when is_function(Fun) ->
+    MaxTime = 600000, %% @TODO use config
+    Delay = 1000, %% @TODO use config
+    Retry = MaxTime div Delay,
+    wait_until(Fun, Retry, Delay).
+
+
+%% @doc Retries function 'Fun' until 'true' is returned or retries are reached with a specified
+%% function execution delay in ms.
+-spec wait_until(fun(), integer(), integer()) -> true | {fail, any()}.
+wait_until(Fun, Retry, Delay) when Retry > 0 ->
+    wait_until_result(Fun, true, Retry, Delay).
+
+
+%% @doc Retries function 'Fun' until the expected result is returned or retries are reached with a specified
+%% function execution delay in ms.
+-spec wait_until_result(fun(), any(), integer(), integer()) -> ok | {fail, any()}.
+wait_until_result(Fun, ExpectedResult, Retry, Delay) when Retry > 0 ->
+    ActualResult = Fun(),
+    case ActualResult of
+        ExpectedResult ->
+            ok;
+        _ when Retry == 1 ->
+            {fail, ActualResult};
+        _ ->
+            timer:sleep(Delay),
+            wait_until_result(Fun, ExpectedResult, Retry-1, Delay)
+    end.
+
+
+%% @doc Waits until no connection to the target node can be established anymore.
+-spec wait_until_offline(node()) -> any().
+wait_until_offline(Node) ->
+    wait_until(fun() ->
+        pang == net_adm:ping(Node)
+               end, retries(), retry_delay()).
+
+
+%% @doc Waits until node1 can or connect to node2
+-spec wait_until_connection(node(), node(), pang | pong) -> any().
+wait_until_connection(Node1, Node2, Expected) ->
+    wait_until(fun() ->
+        Expected == rpc:call(Node1, net_adm, ping, [Node2])
+               end, retries(), retry_delay()).
+
+
+%% @doc Waits until node1 cannot connect to node2 anymore
+-spec wait_until_disconnected(node(), node()) -> any().
+wait_until_disconnected(Node1, Node2) ->
+    wait_until_connection(Node1, Node2, pang).
+
+
+%% @doc Waits until node1 can connect to node2
+-spec wait_until_connected(node(), node()) -> any().
+wait_until_connected(Node1, Node2) ->
+    wait_until_connection(Node1, Node2, pong).
+
+
+%% @doc Waits until a certain registered name pops up on the remote node.
+-spec wait_until_registered(node(), any()) -> any().
+wait_until_registered(Node, Name) ->
+    ct:print("Wait until ~p is up on ~p", [Name, Node]),
+    IsNameRegisteredMember = fun() ->
+                Registered = rpc:call(Node, erlang, registered, []),
+                lists:member(Name, Registered)
+        end,
+    Delay = rt_retry_delay(),
+    Retry = 360000 div Delay,
+    wait_until(IsNameRegisteredMember, Retry, Delay).
+
+
+%% @doc Waits until nodes agree about ownership
+-spec wait_until_nodes_agree_about_ownership([node()]) -> any().
+wait_until_nodes_agree_about_ownership(Nodes) ->
+    lager:info("Wait until nodes agree about ownership ~p", [Nodes]),
+    Results = [ wait_until_owners_according_to(Node, Nodes) || Node <- Nodes ],
+    ?assert(lists:all(fun(X) -> ok =:= X end, Results)).
+
+
+%% @doc Waits until ring owners of the given node match the expected ring owners
+-spec wait_until_owners_according_to(node(), [node()]) -> ok.
+wait_until_owners_according_to(Node, NodeRingOwners) ->
+    ExpectedOwners = lists:usort(NodeRingOwners),
+    AreNodesOwners = fun(N) ->
+        riak_utils:owners_according_to(N) =:= ExpectedOwners
+                     end,
+    ?assertEqual(ok, wait_until(Node, AreNodesOwners)),
+    ok.
+
+
+%TODO Move to config
+rt_retry_delay() -> 500.
+
+retry_delay() -> 1000.
+
+retries() -> 60*2.
+
+%% UNUSED FUNCTIONS
+
+%wait_until_left(Nodes, LeavingNode) ->
+%    wait_until(fun() ->
+%                lists:all(fun(X) -> X == true end,
+%                          pmap(fun(Node) ->
+%                                not
+%                                lists:member(LeavingNode,
+%                                             get_cluster_members(Node))
+%                        end, Nodes))
+%        end, 60*2, 500).
+
+%wait_until_joined(Nodes, ExpectedCluster) ->
+%    wait_until(fun() ->
+%                lists:all(fun(X) -> X == true end,
+%                          pmap(fun(Node) ->
+%                                lists:sort(ExpectedCluster) ==
+%                                lists:sort(get_cluster_members(Node))
+%                        end, Nodes))
+%        end, 60*2, 500).

--- a/test/time_utils.erl
+++ b/test/time_utils.erl
@@ -19,10 +19,15 @@
     wait_until_result/4,
     wait_until_registered/2,
     wait_until_offline/1,
+    wait_until_connection/3,
     wait_until_disconnected/2,
     wait_until_connected/2,
     wait_until_nodes_agree_about_ownership/1,
-    wait_until_owners_according_to/2
+    wait_until_owners_according_to/2,
+
+    retry_delay/0,
+    rt_retry_delay/0,
+    retries/0
 ]).
 
 

--- a/test/time_utils.erl
+++ b/test/time_utils.erl
@@ -7,7 +7,8 @@
 %%% Created : 23. May 2018 16:17
 %%%-------------------------------------------------------------------
 -module(time_utils).
--author("schimpf").
+
+-compile({parse_transform, lager_transform}).
 
 -include_lib("eunit/include/eunit.hrl").
 


### PR DESCRIPTION
* Cleaned up print statements in test code
  * ct:print is used for important things (test case success, node crash/restart, failures)
  * lager:info is used for additional debugging information

* Fixed node kill/restart
  * Killing nodes via signal does not suffice, ct framework still thinks node is running even though its dead

* Reuse of node structure for each suite
  * Fixed bug where ports are being used
  * Tests now take 3m instead of 6m on average

* Simplified release_test.sh

There seems to be a bug left, but I cannot reproduce it. Test case multiple_dcs_node_failure_SUITE:update_during_cluster_failure_test/1 fails on peters run, sometimes where the actual value seems to be behind the expected value (3 != 4). I had the same error, so I increased the read retry count to 10. Don't know what other reason there may be that this case still fails.