### PR TITLE
implemented missing client-abort functionality

### DIFF
--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -121,7 +121,7 @@ unregister_hook(Prefix, Bucket) ->
 start_transaction(Clock, Properties) ->
     cure:start_transaction(Clock, Properties, false).
 
--spec abort_transaction(TxId::txid()) -> {error, reason()}.
+-spec abort_transaction(TxId::txid()) -> ok | {error, reason()}.
 abort_transaction(TxId) ->
     cure:abort_transaction(TxId).
 

--- a/src/antidote_pb_txn.erl
+++ b/src/antidote_pb_txn.erl
@@ -93,6 +93,9 @@ process(#apbaborttransaction{transaction_descriptor=Td}, State) ->
     TxId = binary_to_term(Td),
     Response = antidote:abort_transaction(TxId),
     case Response of
+        ok ->
+            {reply, antidote_pb_codec:encode(operation_response, ok),
+                State};
         {error, Reason} ->
             {reply, antidote_pb_codec:encode(operation_response,
                                              {error, Reason}),

--- a/src/clocksi_interactive_coord.erl
+++ b/src/clocksi_interactive_coord.erl
@@ -708,6 +708,10 @@ execute_command(prepare, Protocol, Sender, State0) ->
             prepare(State)
     end;
 
+%% @doc Abort the current transaction
+execute_command(abort, _Protocol, Sender, State) ->
+    abort(State#coord_state{from=Sender});
+
 %% @doc Perform a single read, synchronous
 execute_command(read, {Key, Type}, Sender, State = #coord_state{
     transaction=Transaction,

--- a/src/cure.erl
+++ b/src/cure.erl
@@ -52,10 +52,12 @@ start_transaction(Clock, Properties, KeepAlive) ->
 start_transaction(Clock, Properties) ->
     clocksi_istart_tx(Clock, Properties, false).
 
--spec abort_transaction(txid()) -> {error, reason()}.
-abort_transaction(_TxId) ->
-    %% TODO
-    {error, operation_not_implemented}.
+-spec abort_transaction(txid()) -> ok | {error, reason()}.
+abort_transaction(TxId) ->
+    case gen_statem:call(TxId#tx_id.server_pid, {abort, []}) of
+        {error, {aborted, _TxId}} -> ok;
+        {error, Reason} -> {error, Reason}
+    end.
 
 -spec commit_transaction(txid()) ->
                                 {ok, snapshot_time()} | {error, reason()}.

--- a/test/antidote_SUITE.erl
+++ b/test/antidote_SUITE.erl
@@ -17,14 +17,10 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-%% @doc log_test: Test that perform NumWrites increments to the key:key1.
-%%      Each increment is sent to a random node of the cluster.
-%%      Test normal behavior of the logging layer
-%%      Performs a read to the first node of the cluster to check whether all the
-%%      increment operations where successfully applied.
-%%  Variables:  N:  Number of nodes
-%%              Nodes: List of the nodes that belong to the built cluster
-%%
+%% @doc antidote_SUITE:
+%%    Test the basic api of antidote
+%%    static and interactive transactions with single and multiple Objects
+%%    interactive transaction with abort
 
 -module(antidote_SUITE).
 
@@ -45,6 +41,7 @@
          static_txn_multi_objects/1,
          static_txn_multi_objects_clock/1,
          interactive_txn/1,
+         interactive_txn_abort/1,
          random_test/1]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -75,6 +72,7 @@ all() ->
      static_txn_multi_objects,
      static_txn_multi_objects_clock,
      interactive_txn,
+     interactive_txn_abort,
      random_test
     ].
 
@@ -205,6 +203,23 @@ txn_seq_update_check(Node, TxId, Updates) ->
                       Res = rpc:call(Node, antidote, update_objects, [[Update], TxId]),
                       ?assertMatch(ok, Res)
               end, Updates).
+
+interactive_txn_abort(Config) ->
+    [Node | _Nodes] = proplists:get_value(nodes, Config),
+    Type = antidote_crdt_counter_pn,
+    Bucket = antidote_bucket,
+    Key = antidote_int_abort_m1,
+    Object = {Key, Type, Bucket},
+    Update = {Object, increment, 1},
+    {ok, TxId} = rpc:call(Node, antidote, start_transaction, [ignore, []]),
+    ok = rpc:call(Node, antidote, update_objects, [[Update], TxId]),
+    ok = rpc:call(Node, antidote, abort_transaction, [TxId]), % must abort successfully
+
+    {ok, TxId2} = rpc:call(Node, antidote, start_transaction, [ignore, []]),
+    %% read object
+    {ok, Res} = rpc:call(Node, antidote, read_objects, [[Object], TxId2]),
+    {ok, _} = rpc:call(Node, antidote, commit_transaction, [TxId2]),
+    ?assertEqual([0], Res). % prev txn is aborted so read returns 0
 
 %% Test that perform NumWrites increments to the key:key1.
 %%      Each increment is sent to a random node of the cluster.


### PR DESCRIPTION
Before, a client abort only yielded an error without influencing the running transaction, which leads to abandoned transaction coordinators. If enough transactions are aborted, you hit the system limit of running processes and Antidote dies.

This update implements the functionality for client aborts using the existing abort functionality of transaction coordinators. Please have a look at it. I am not sure whether I got the semantics of the abort(...) function in clocksi_interactive_coord right.