### PR TITLE
Feature: List all known keys

### DIFF
--- a/src/antidote.erl
+++ b/src/antidote.erl
@@ -50,7 +50,8 @@
           get_objects/3,
           get_log_operations/1,
           get_default_txn_properties/0,
-          get_txn_property/2
+          get_txn_property/2,
+          all_keys/1
         ]).
 
 %% Public API
@@ -100,6 +101,15 @@ create_object(_Key, _Type, _Bucket) ->
 
 delete_object({_Key, _Type, _Bucket}) ->
     %% TODO: Object deletion is not currently supported
+    {error, operation_not_supported}.
+
+
+%% returns all known keys at snapshot time
+-spec all_keys(snapshot_time()) -> {ok, [bound_object()]} | {error, term()}.
+all_keys(ignore) ->
+    {ok, logging_vnode:all_keys(ignore)};
+all_keys(_SnapshotTime) ->
+    %% TODO: filter time
     {error, operation_not_supported}.
 
 %% Register a post commit hook.

--- a/test/multidc/antidote_SUITE.erl
+++ b/test/multidc/antidote_SUITE.erl
@@ -48,7 +48,8 @@
          random_test/1,
          shard_count/1,
          dc_count/1,
-         meta_data_env_test/1
+         meta_data_env_test/1,
+         list_known_keys/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -76,7 +77,8 @@ all() ->
      dc_count,
      dummy_test,
      random_test,
-     meta_data_env_test
+     meta_data_env_test,
+     list_known_keys
     ].
 
 %% Tests that add_nodes_to_dc is idempotent
@@ -202,3 +204,50 @@ meta_data_env_test(Config) ->
     lists:foreach(fun(Node) ->
         time_utils:wait_until(fun() -> Value = rpc:call(Node, logging_vnode, is_sync_log, []), Value == OldValue end)
                   end, DC).
+
+list_known_keys(Config) ->
+    Bucket = ?BUCKET,
+    [[Node, _Node2] | _] = proplists:get_value(clusters, Config),
+    Type = antidote_crdt_counter_pn,
+    Keys = [antidote_int_m1, antidote_int_m2, antidote_int_m3, antidote_int_m4],
+    IncValues = [1, 2, 3, 4],
+    Objects = lists:map(fun(Key) -> {Key, Type, Bucket} end, Keys),
+    Updates = lists:map(fun({Object, IncVal}) ->
+        {Object, increment, IncVal}
+                        end, lists:zip(Objects, IncValues)),
+    {ok, TxId} = rpc:call(Node, antidote, start_transaction, [ignore, []]),
+    %% update objects one by one.
+    txn_seq_update_check(Node, TxId, Updates),
+    %% read objects one by one
+    txn_seq_read_check(Node, TxId, Objects, [1, 2, 3, 4]),
+    {ok, Clock} = rpc:call(Node, antidote, commit_transaction, [TxId]),
+
+    {ok, TxId2} = rpc:call(Node, antidote, start_transaction, [Clock, []]),
+    %% read objects all at once
+    {ok, Res} = rpc:call(Node, antidote, read_objects, [Objects, TxId2]),
+    {ok, _} = rpc:call(Node, antidote, commit_transaction, [TxId2]),
+    ?assertEqual([1, 2, 3, 4], Res),
+
+    %% list known keys
+    %% these keys will contain all keys from the previous tests in this suite, too
+    {ok, AllKeys} = rpc:call(Node, antidote, all_keys, [ignore]),
+    ct:pal("Keys: ~p", [AllKeys]),
+    %% at least 4 keys
+    ?assertEqual(true, length(AllKeys) >= 4),
+    %% be able to find all keys
+    lists:foreach(fun(K) ->
+        true = lists:member({K, Type, Bucket}, AllKeys)
+                  end, Keys).
+
+txn_seq_read_check(Node, TxId, Objects, ExpectedValues) ->
+    lists:map(fun({Object, Expected}) ->
+        {ok, [Val]} = rpc:call(Node, antidote, read_objects, [[Object], TxId]),
+        ?assertEqual(Expected, Val)
+              end, lists:zip(Objects, ExpectedValues)).
+
+
+txn_seq_update_check(Node, TxId, Updates) ->
+    lists:map(fun(Update) ->
+        Res = rpc:call(Node, antidote, update_objects, [[Update], TxId]),
+        ?assertMatch(ok, Res)
+              end, Updates).


### PR DESCRIPTION
Draft implementation of listing all keys in an AntidoteDB data center (over all shards in the cluster). The new API method return a list of bound objects (`[{Key, Type Bucket}]`).

The `riak_core` part is implemented and the API in` antidote.erl` is extended.

To do:
* [ ] Check semantics of snapshot time and implemented non `ignore` Snapshot filter
* [ ] Verify again which log entires to use to list keys